### PR TITLE
feat: add omh as short alias for oh-my-harness CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {
-    "oh-my-harness": "dist/bin/oh-my-harness.js"
+    "oh-my-harness": "dist/bin/oh-my-harness.js",
+    "omh": "dist/bin/oh-my-harness.js"
   },
   "main": "dist/cli/index.js",
   "types": "dist/cli/index.d.ts",


### PR DESCRIPTION
Users can now use `omh` instead of `oh-my-harness`:
  omh init, omh catalog list, omh hook add, omh sync

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * CLI 명령어에 새로운 단축 별칭이 추가되었습니다. 기존 명령어와 함께 더 간편한 방식으로 도구에 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->