### PR TITLE
fix: resolve actual hook script path from settings.json

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -102,7 +102,7 @@ export async function testCommand(options: TestCommandOptions = {}): Promise<{
   }
 
   const enforcementCases = generateTestCases(hooks, enforcement, currentBranch);
-  const blockCases = generateBlockTestCases(hookEntries, builtinBlocks, currentBranch);
+  const blockCases = generateBlockTestCases(hookEntries, builtinBlocks, currentBranch, hooks);
   // Block cases take priority — only keep enforcement cases for categories not covered by blocks
   const blockCategories = new Set(blockCases.map((c) => c.category));
   const uniqueEnforcementCases = enforcementCases.filter((c) => !blockCategories.has(c.category));

--- a/src/cli/harness-tester.ts
+++ b/src/cli/harness-tester.ts
@@ -270,6 +270,7 @@ export function generateBlockTestCases(
   hookEntries: HookEntry[],
   blocks: BuildingBlock[],
   currentBranch?: string,
+  registeredHooks?: { event: string; matcher: string; command: string }[],
 ): TestCase[] {
   const cases: TestCase[] = [];
 
@@ -279,7 +280,24 @@ export function generateBlockTestCases(
     if (!block.canBlock) continue;
 
     const params = applyDefaults(block, entry.params);
-    const hookScript = `.claude/hooks/catalog-${block.id}.sh`;
+    // Find actual script path from registered hooks, fallback to catalog- prefix
+    // Map block ids to enforcement script name patterns
+    const blockIdAliases: Record<string, string[]> = {
+      "path-guard": ["path-guard", "file-guard"],
+      "command-guard": ["command-guard"],
+      "branch-guard": ["branch-guard"],
+      "lockfile-guard": ["lockfile-guard"],
+      "secret-file-guard": ["secret-file-guard"],
+      "tdd-guard": ["tdd-guard"],
+    };
+    const aliases = blockIdAliases[block.id] ?? [block.id];
+    const matchedHook = registeredHooks?.find((h) => {
+      const scriptName = h.command.replace(/^bash\s+/, "");
+      return aliases.some((alias) => scriptName.includes(alias));
+    });
+    const hookScript = matchedHook
+      ? matchedHook.command.replace(/^bash\s+/, "")
+      : `.claude/hooks/catalog-${block.id}.sh`;
 
     switch (block.id) {
       case "path-guard": {

--- a/tests/unit/cli-test.test.ts
+++ b/tests/unit/cli-test.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import yaml from "js-yaml";
+// updated: generateBlockTestCases now receives registeredHooks
 // updated: block cases take priority over enforcement cases
 import { formatCategoryName, testCommand } from "../../src/cli/commands/test.js";
 

--- a/tests/unit/harness-tester.test.ts
+++ b/tests/unit/harness-tester.test.ts
@@ -560,6 +560,21 @@ describe("generateBlockTestCases", () => {
     expect(cases[0].category).toBe("path-guard");
   });
 
+  it("uses registered hook path when provided", () => {
+    const entries = [{ block: "path-guard", params: { blockedPaths: ["dist/"] } }];
+    const registeredHooks = [
+      { event: "PreToolUse", matcher: "Edit|Write", command: "bash .claude/hooks/harness-file-guard.sh" },
+    ];
+    const cases = generateBlockTestCases(entries, builtinBlocks, undefined, registeredHooks);
+    expect(cases[0].hookScript).toBe(".claude/hooks/harness-file-guard.sh");
+  });
+
+  it("falls back to catalog- prefix when no registered hook matches", () => {
+    const entries = [{ block: "path-guard", params: { blockedPaths: ["dist/"] } }];
+    const cases = generateBlockTestCases(entries, builtinBlocks);
+    expect(cases[0].hookScript).toBe(".claude/hooks/catalog-path-guard.sh");
+  });
+
   it("generates block/allow cases for command-guard with patterns params", () => {
     const entries = [{ block: "command-guard", params: { patterns: ["rm -rf /", "sudo rm"] } }];
     const cases = generateBlockTestCases(entries, builtinBlocks);


### PR DESCRIPTION
## Summary
- `omh test`가 enforcement 경로(harness-*.sh)로 생성된 스크립트를 찾지 못하는 문제 수정
- `generateBlockTestCases`가 settings.json에 등록된 실제 hook 경로를 사용하도록 변경
- 블록 id → enforcement 스크립트명 alias 매핑 (path-guard → file-guard 등)

> **Note**: PR #20에서 enforcement 경로가 완전히 제거되면 이 alias 매핑은 불필요해집니다.

## Test plan
- [x] 716 tests / 68 files 전부 통과
- [x] registered hook path 매칭 테스트
- [x] fallback to catalog- prefix 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)