### PR TITLE
feat: add no-verify-guard block (powered by block-no-verify)

### DIFF
--- a/presets/_base/preset.yaml
+++ b/presets/_base/preset.yaml
@@ -67,6 +67,14 @@ hooks:
           fi
         done
         exit 0
+    - id: "base-no-verify-guard"
+      matcher: "Bash"
+      description: "Blocks git hook bypass via --no-verify flags (uses block-no-verify)"
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+        INPUT=$(cat)
+        echo "$INPUT" | npx --yes block-no-verify@1.1.2
     - id: "base-test-before-commit"
       matcher: "Bash"
       description: "Ensures tests pass before git commit"

--- a/src/catalog/blocks/index.ts
+++ b/src/catalog/blocks/index.ts
@@ -11,12 +11,14 @@ import { formatOnSave } from "./format-on-save.js";
 import { autoPr } from "./auto-pr.js";
 import { secretFileGuard } from "./secret-file-guard.js";
 import { tddGuard } from "./tdd-guard.js";
+import { noVerifyGuard } from "./no-verify-guard.js";
 
 export const builtinBlocks: BuildingBlock[] = [
   branchGuard,
   commitTestGate,
   commitTypecheckGate,
   commandGuard,
+  noVerifyGuard,
   pathGuard,
   lockfileGuard,
   lintOnSave,

--- a/src/catalog/blocks/no-verify-guard.ts
+++ b/src/catalog/blocks/no-verify-guard.ts
@@ -1,0 +1,18 @@
+import type { BuildingBlock } from "../types.js";
+
+export const noVerifyGuard: BuildingBlock = {
+  id: "no-verify-guard",
+  name: "No-Verify Guard",
+  description:
+    "Blocks git commands that bypass hooks via --no-verify flags (powered by block-no-verify)",
+  category: "security",
+  event: "PreToolUse",
+  matcher: "Bash",
+  canBlock: true,
+  params: [],
+  tags: ["security", "git", "hooks", "guard"],
+  template: `#!/bin/bash
+set -euo pipefail
+INPUT=$(cat)
+echo "$INPUT" | npx --yes block-no-verify@1.1.2`,
+};


### PR DESCRIPTION
## Summary

Adds a new `no-verify-guard` catalog block that uses the [`block-no-verify`](https://github.com/tupe12334/block-no-verify) package (v1.1.2) to detect and block git commands that attempt to bypass hooks.

Also included in the `_base` preset by default so all generated harnesses are protected out of the box.

## Problem

oh-my-harness blocks dangerous commands, enforces test gates, and guards branches — but there's a silent escape hatch: the `--no-verify` flag lets agents skip ALL hooks in one argument, bypassing every guard in the harness.

## Solution

The `no-verify-guard` block delegates to `block-no-verify`, a purpose-built package that handles:
- `--no-verify` flag detection across git subcommands
- `-n` shorthand detection on `git commit`
- `core.hooksPath` override detection

Generated hook in `.claude/settings.json`:
```json
{
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Bash",
        "hooks": [{ "type": "command", "command": "bash .claude/hooks/no-verify-guard.sh" }]
      }
    ]
  }
}
```

Generated shell script delegates entirely to the package — no inline reimplementation.

## Test plan

- [ ] Run `omh catalog list` and verify `no-verify-guard` appears
- [ ] Run `omh init "test project"` and verify `.claude/hooks/no-verify-guard.sh` is generated with `npx --yes block-no-verify@1.1.2`
- [ ] Verify a `git commit` command is blocked when the hook runs
- [ ] Verify normal `git commit` commands (without bypass flags) pass through

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Git 훅 우회 방지**: `--no-verify` 플래그를 사용하여 깃 훅을 바이패스하려는 시도를 자동으로 차단하는 새로운 보안 기능이 추가되었습니다. Bash 환경에서 활성화되어 팀의 깃 훅 정책 준수를 강제합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->