### PR TITLE
fix: python detector recognizes Pipfile, manage.py, .python-version, black, isort

### DIFF
--- a/src/detector/detectors/python.ts
+++ b/src/detector/detectors/python.ts
@@ -119,20 +119,24 @@ export const pythonDetector: Detector = {
     // pyproject.toml [tool.isort] detection
     if (pyprojectContent?.includes("[tool.isort]")) {
       isPython = true;
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      lintCommands.push(`${prefix}isort --check-only .`);
       if (!detectedFiles.includes("pyproject.toml")) detectedFiles.push("pyproject.toml");
     }
 
     // pytest.ini detection
     if (await fileExists(pytestIniPath)) {
       isPython = true;
-      testCommands.push(isPoetry ? "poetry run pytest" : "pytest");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      testCommands.push(`${prefix}pytest`);
       detectedFiles.push("pytest.ini");
     }
 
     // conftest.py detection
     if (await fileExists(conftestPath)) {
       isPython = true;
-      testCommands.push(isPoetry ? "poetry run pytest" : "pytest");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      testCommands.push(`${prefix}pytest`);
       detectedFiles.push("conftest.py");
     }
 
@@ -140,42 +144,48 @@ export const pythonDetector: Detector = {
     const setupCfgContent = await readTextFile(setupCfgPath);
     if (setupCfgContent?.includes("[tool:pytest]")) {
       isPython = true;
-      testCommands.push(isPoetry ? "poetry run pytest" : "pytest");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      testCommands.push(`${prefix}pytest`);
       detectedFiles.push("setup.cfg");
     }
 
     // .flake8 detection
     if (await fileExists(flake8Path)) {
       isPython = true;
-      lintCommands.push(isPoetry ? "poetry run flake8" : "flake8");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      lintCommands.push(`${prefix}flake8`);
       detectedFiles.push(".flake8");
     }
 
     // ruff.toml detection
     if (await fileExists(ruffTomlPath)) {
       isPython = true;
-      lintCommands.push(isPoetry ? "poetry run ruff check" : "ruff check");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      lintCommands.push(`${prefix}ruff check`);
       detectedFiles.push("ruff.toml");
     }
 
     // pyproject.toml [tool.ruff] detection
     if (pyprojectContent?.includes("[tool.ruff]")) {
       isPython = true;
-      lintCommands.push(isPoetry ? "poetry run ruff check" : "ruff check");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      lintCommands.push(`${prefix}ruff check`);
       if (!detectedFiles.includes("pyproject.toml")) detectedFiles.push("pyproject.toml");
     }
 
     // mypy.ini detection
     if (await fileExists(mypyIniPath)) {
       isPython = true;
-      typecheckCommands.push(isPoetry ? "poetry run mypy ." : "mypy .");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      typecheckCommands.push(`${prefix}mypy .`);
       detectedFiles.push("mypy.ini");
     }
 
     // pyproject.toml [tool.mypy] detection
     if (pyprojectContent?.includes("[tool.mypy]")) {
       isPython = true;
-      typecheckCommands.push(isPoetry ? "poetry run mypy ." : "mypy .");
+      const prefix = isPoetry ? "poetry run " : isPipenv ? "pipenv run " : "";
+      typecheckCommands.push(`${prefix}mypy .`);
       if (!detectedFiles.includes("pyproject.toml")) detectedFiles.push("pyproject.toml");
     }
 

--- a/tests/unit/detector/python-detector.test.ts
+++ b/tests/unit/detector/python-detector.test.ts
@@ -300,17 +300,32 @@ describe("pythonDetector", () => {
     expect(result.languages).toContain("python");
   });
 
-  it("detects [tool.black] in pyproject.toml", async () => {
+  it("detects [tool.black] in pyproject.toml with exact lint command", async () => {
     await writeFile(tmpDir, "pyproject.toml", '[tool.black]\nline-length = 120\n');
     const result = await pythonDetector.detect(tmpDir);
     expect(result.languages).toContain("python");
-    expect(result.lintCommands).toEqual(expect.arrayContaining([expect.stringContaining("black")]));
+    expect(result.lintCommands).toContain("black --check .");
   });
 
-  it("detects [tool.isort] in pyproject.toml", async () => {
+  it("detects [tool.isort] in pyproject.toml with lint command", async () => {
     await writeFile(tmpDir, "pyproject.toml", '[tool.isort]\nprofile = "black"\n');
     const result = await pythonDetector.detect(tmpDir);
     expect(result.languages).toContain("python");
+    expect(result.lintCommands).toContain("isort --check-only .");
+  });
+
+  it("uses pipenv run prefix for pytest when Pipfile exists", async () => {
+    await writeFile(tmpDir, "Pipfile", '[packages]\n');
+    await writeFile(tmpDir, "pytest.ini", "[pytest]\n");
+    const result = await pythonDetector.detect(tmpDir);
+    expect(result.testCommands).toContain("pipenv run pytest");
+  });
+
+  it("uses pipenv run prefix for ruff when Pipfile exists", async () => {
+    await writeFile(tmpDir, "Pipfile", '[packages]\n');
+    await writeFile(tmpDir, "ruff.toml", "[lint]\n");
+    const result = await pythonDetector.detect(tmpDir);
+    expect(result.lintCommands).toContain("pipenv run ruff check");
   });
 
   it("has name 'python'", () => {


### PR DESCRIPTION
Django projects using Pipfile/pipenv were not detected because the
python detector only checked pyproject.toml sections, requirements.txt,
and specific tool configs. Now detects:
- Pipfile → pipenv package manager
- manage.py → Django framework
- .python-version → Python project indicator
- [tool.black] → black linter
- [tool.isort] → isort import sorter

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * pipenv 패키지 매니저 지원 추가 — 관련 실행 명령에 pipenv run 접두사 자동 적용
  * Django 프로젝트 자동 감지 (manage.py 기반)
  * .python-version 파일로 Python 버전 자동 인식
  * pyproject.toml 내 Black/isort 설정 인식 확대 — 해당 린트 명령 자동 생성 및 설정 파일 포함
  * 탐지된 프레임워크 목록을 중복 제거하여 반환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->