### PR TITLE
fix: command-guard grep uses -- to support dash-prefixed patterns

### DIFF
--- a/src/catalog/blocks/command-guard.ts
+++ b/src/catalog/blocks/command-guard.ts
@@ -25,7 +25,7 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 [[ -z "$COMMAND" ]] && exit 0
 PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
 for PATTERN in "\${PATTERNS[@]}"; do
-  if echo "$COMMAND" | grep -qF "$PATTERN"; then
+  if echo "$COMMAND" | grep -qF -- "$PATTERN"; then
     _log_event "block" "oh-my-harness: command matches blocked pattern: $PATTERN"
     echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: command matches blocked pattern: $PATTERN\\"}"
     exit 0

--- a/tests/unit/command-guard-block.test.ts
+++ b/tests/unit/command-guard-block.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { commandGuard } from "../../src/catalog/blocks/command-guard.js";
+
+describe("commandGuard block", () => {
+  it("has correct metadata", () => {
+    expect(commandGuard.id).toBe("command-guard");
+    expect(commandGuard.event).toBe("PreToolUse");
+    expect(commandGuard.matcher).toBe("Bash");
+    expect(commandGuard.canBlock).toBe(true);
+  });
+
+  it("template uses grep -- to support patterns starting with dashes", () => {
+    // Without --, patterns like --no-verify are interpreted as grep options
+    expect(commandGuard.template).toContain('grep -qF -- ');
+  });
+});


### PR DESCRIPTION
grep -qF "$PATTERN" interprets --no-verify as a grep option.
Added -- separator so patterns starting with dashes are treated
as search strings, not flags.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 명령 검사 시 대시 문자로 시작하는 패턴을 올바르게 처리하도록 개선

* **테스트**
  * 명령 가드 블록의 핵심 기능과 동작을 검증하는 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->