### PR TITLE
fix: TDD guard test record consumption + tsc PATH resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.4.2",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.4.2",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.9.0",
+  "version": "0.8.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {

--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -74,8 +74,11 @@ fi
 
 # edit-history에서 테스트 파일 검색
 if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
-  # 테스트 먼저 수정됨 → 소스 기록 + 통과
-  UPDATED=$(jq --arg f "\$FILE_PATH" '.edits += [$f] | .edits |= unique' "\$HISTORY_FILE" 2>/dev/null) || true
+  # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
+  UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
+    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_"))) | not)]
+    | .edits += [$f] | .edits |= unique
+  ' "\$HISTORY_FILE" 2>/dev/null) || true
   if [[ -n "\$UPDATED" ]]; then
     echo "\$UPDATED" > "\$HISTORY_FILE"
   fi

--- a/src/detector/detectors/node.ts
+++ b/src/detector/detectors/node.ts
@@ -183,7 +183,7 @@ export const nodeDetector: Detector = {
     const tsconfigPath = path.join(projectDir, "tsconfig.json");
     if (await fileExists(tsconfigPath)) {
       languages.push("typescript");
-      typecheckCommands.push("tsc --noEmit");
+      typecheckCommands.push("npx tsc --noEmit");
       detectedFiles.push("tsconfig.json");
     } else {
       languages.push("javascript");

--- a/tests/integration/tdd-guard-execution.test.ts
+++ b/tests/integration/tdd-guard-execution.test.ts
@@ -140,6 +140,33 @@ describe("tdd-guard execution", () => {
   );
 
   it.runIf(hasJq())(
+    "blocks second source edit after first passed — test record consumed",
+    async () => {
+      const historyPath = join(tmpDir, ".claude/hooks/.state/edit-history.json");
+      // Turn 1: record test file
+      await writeFile(historyPath, JSON.stringify({ edits: ["tests/unit/event-logger.test.ts"] }));
+
+      // Turn 1: source edit passes (consumes the test record)
+      runScript(
+        scriptPath,
+        JSON.stringify({ tool_name: "Edit", tool_input: { file_path: "src/event-logger.ts" } }),
+        tmpDir,
+      );
+
+      // Turn 2: same source edit again — should block because test record was consumed
+      const stdout = runScript(
+        scriptPath,
+        JSON.stringify({ tool_name: "Edit", tool_input: { file_path: "src/event-logger.ts" } }),
+        tmpDir,
+      );
+      const trimmed = stdout.trim();
+      expect(trimmed).not.toBe("");
+      const result = JSON.parse(trimmed);
+      expect(result.decision).toBe("block");
+    },
+  );
+
+  it.runIf(hasJq())(
     "records decision=block in events.jsonl when source file blocked",
     async () => {
       // No edit-history → block

--- a/tests/unit/detector/init-integration.test.ts
+++ b/tests/unit/detector/init-integration.test.ts
@@ -97,7 +97,7 @@ describe("NL init flow + detectProject integration", () => {
       testCommands: ["pnpm test"],
       lintCommands: ["eslint ."],
       buildCommands: ["pnpm build"],
-      typecheckCommands: ["tsc --noEmit"],
+      typecheckCommands: ["npx tsc --noEmit"],
       blockedPaths: ["node_modules/"],
       detectedFiles: ["package.json", "tsconfig.json"],
     };

--- a/tests/unit/detector/node-detector.test.ts
+++ b/tests/unit/detector/node-detector.test.ts
@@ -230,7 +230,7 @@ describe("nodeDetector", () => {
     const result = await nodeDetector.detect(tmpDir);
 
     expect(result.languages).toContain("typescript");
-    expect(result.typecheckCommands).toContain("tsc --noEmit");
+    expect(result.typecheckCommands).toContain("npx tsc --noEmit");
     expect(result.detectedFiles).toContain("tsconfig.json");
   });
 

--- a/tests/unit/detector/project-detector.test.ts
+++ b/tests/unit/detector/project-detector.test.ts
@@ -80,7 +80,7 @@ describe("detectProject", () => {
         testCommands: ["pnpm test"],
         lintCommands: ["eslint --fix"],
         buildCommands: ["pnpm build"],
-        typecheckCommands: ["tsc --noEmit"],
+        typecheckCommands: ["npx tsc --noEmit"],
         blockedPaths: [".next/", "node_modules/"],
         detectedFiles: ["package.json", "tsconfig.json"],
       }),
@@ -94,7 +94,7 @@ describe("detectProject", () => {
     expect(facts.testCommands).toEqual(["pnpm test"]);
     expect(facts.lintCommands).toEqual(["eslint --fix"]);
     expect(facts.buildCommands).toEqual(["pnpm build"]);
-    expect(facts.typecheckCommands).toEqual(["tsc --noEmit"]);
+    expect(facts.typecheckCommands).toEqual(["npx tsc --noEmit"]);
     expect(facts.blockedPaths).toEqual([".next/", "node_modules/"]);
     expect(facts.detectedFiles).toEqual(["package.json", "tsconfig.json"]);
   });

--- a/tests/unit/prompt-templates.test.ts
+++ b/tests/unit/prompt-templates.test.ts
@@ -10,7 +10,7 @@ const fullFacts: ProjectFacts = {
   testCommands: ["pnpm test"],
   lintCommands: ["eslint --fix"],
   buildCommands: ["pnpm build"],
-  typecheckCommands: ["tsc --noEmit"],
+  typecheckCommands: ["npx tsc --noEmit"],
   blockedPaths: [".next/", "node_modules/", "dist/"],
   detectedFiles: ["package.json", "tsconfig.json"],
 };
@@ -72,7 +72,7 @@ describe("buildHarnessGenerationPrompt with projectFacts", () => {
 
   it("includes typecheck commands in facts section", () => {
     const prompt = buildHarnessGenerationPrompt("my app", undefined, fullFacts);
-    expect(prompt).toContain("- Typecheck commands: tsc --noEmit");
+    expect(prompt).toContain("- Typecheck commands: npx tsc --noEmit");
   });
 
   it("includes blocked paths in facts section", () => {


### PR DESCRIPTION
## Summary
- **TDD guard 버그 수정**: 소스 파일이 TDD 체크를 통과한 후 매칭된 테스트 기록을 소비(제거)하도록 변경. 이전에는 세션 내 2턴째부터 테스트 수정 없이도 소스 수정이 통과되는 버그가 있었음
- **tsc PATH 버그 수정**: node detector가 `tsc --noEmit` 대신 `npx tsc --noEmit`을 출력하도록 변경. hook 환경에서 `node_modules/.bin`이 PATH에 없어 `tsc`를 찾지 못하는 문제 해결
- **버전 범프**: 0.8.0 → 0.8.1

## Test plan
- [x] TDD guard: 소스 수정 통과 후 같은 파일 재수정 시 블록되는지 확인 (새 통합 테스트 추가)
- [x] tsc: `npx tsc --noEmit`이 detector 출력에 포함되는지 확인
- [x] 전체 테스트 스위트 통과 (850+ tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * TDD 가드가 이전 테스트 기록을 소비하도록 동작 개선
  * TypeScript 타입 체크 명령 실행 방식 npx 사용으로 변경

* **테스트**
  * 통합 및 단위 테스트 기대치와 새 통합 시나리오 추가·갱신

* **기타**
  * 패키지 버전 0.8.0 → 0.9.0 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->