### PR TITLE
feat: add GitHub star prompt on first init

### DIFF
--- a/src/cli/github-star.ts
+++ b/src/cli/github-star.ts
@@ -1,0 +1,44 @@
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getConfigDir } from "../nl/config-store.js";
+
+const execFileAsync = promisify(execFileCb);
+const REPO = "kyu1204/oh-my-harness";
+const STATE_FILE = "star-prompt.json";
+
+interface StarState {
+  prompted: boolean;
+}
+
+function getStatePath(): string {
+  return path.join(getConfigDir(), STATE_FILE);
+}
+
+export async function hasStarPromptBeenShown(): Promise<boolean> {
+  try {
+    const raw = await fs.readFile(getStatePath(), "utf-8");
+    const state = JSON.parse(raw) as StarState;
+    return state.prompted === true;
+  } catch {
+    return false;
+  }
+}
+
+export async function markStarPromptShown(): Promise<void> {
+  const dir = getConfigDir();
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(getStatePath(), JSON.stringify({ prompted: true }, null, 2) + "\n", "utf-8");
+}
+
+export async function starRepo(): Promise<boolean> {
+  try {
+    await execFileAsync("gh", ["api", `user/starred/${REPO}`, "-X", "PUT"], {
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/cli/github-star.ts
+++ b/src/cli/github-star.ts
@@ -29,7 +29,24 @@ export async function hasStarPromptBeenShown(): Promise<boolean> {
 export async function markStarPromptShown(): Promise<void> {
   const dir = getConfigDir();
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(getStatePath(), JSON.stringify({ prompted: true }, null, 2) + "\n", "utf-8");
+
+  const statePath = getStatePath();
+  let prev: Record<string, unknown> = {};
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      prev = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Missing or invalid state file falls back to a fresh object.
+  }
+
+  await fs.writeFile(
+    statePath,
+    JSON.stringify({ ...prev, prompted: true }, null, 2) + "\n",
+    "utf-8",
+  );
 }
 
 export async function starRepo(): Promise<boolean> {

--- a/src/cli/tui/init-flow.ts
+++ b/src/cli/tui/init-flow.ts
@@ -18,6 +18,7 @@ import { mergeEnforcementAndHooks } from "../../core/harness-converter.js";
 import type { HarnessConfig } from "../../core/harness-schema.js";
 import { HarnessConfigSchema } from "../../core/harness-schema.js";
 import { detectProject } from "../../detector/project-detector.js";
+import { hasStarPromptBeenShown, markStarPromptShown, starRepo } from "../github-star.js";
 import type { ProjectFacts } from "../../detector/types.js";
 
 function getDefaultPresetsDir(): string {
@@ -599,6 +600,26 @@ export async function runInitTUI(options?: {
   summaryLines.push("  3. Restart your Claude Code session");
 
   p.note(summaryLines.join("\n"), "Harness configured successfully!");
+
+  // Step 8: GitHub Star Prompt (first time only)
+  if (!(await hasStarPromptBeenShown())) {
+    const wantsStar = await p.confirm({
+      message: "Enjoying oh-my-harness? Star us on GitHub?",
+      initialValue: true,
+    });
+
+    if (!p.isCancel(wantsStar)) {
+      await markStarPromptShown();
+      if (wantsStar) {
+        const ok = await starRepo();
+        if (ok) {
+          p.log.success("Thanks for the star!");
+        } else {
+          p.log.info("Star us anytime: https://github.com/kyu1204/oh-my-harness");
+        }
+      }
+    }
+  }
 
   p.outro("Happy coding!");
 }

--- a/src/cli/tui/init-flow.ts
+++ b/src/cli/tui/init-flow.ts
@@ -602,23 +602,31 @@ export async function runInitTUI(options?: {
   p.note(summaryLines.join("\n"), "Harness configured successfully!");
 
   // Step 8: GitHub Star Prompt (first time only)
-  if (!(await hasStarPromptBeenShown())) {
-    const wantsStar = await p.confirm({
-      message: "Enjoying oh-my-harness? Star us on GitHub?",
-      initialValue: true,
-    });
+  try {
+    if (!(await hasStarPromptBeenShown())) {
+      const wantsStar = await p.confirm({
+        message: "Enjoying oh-my-harness? Star us on GitHub?",
+        initialValue: true,
+      });
 
-    if (!p.isCancel(wantsStar)) {
+      // Mark shown regardless of cancel so the prompt never repeats
       await markStarPromptShown();
-      if (wantsStar) {
-        const ok = await starRepo();
-        if (ok) {
-          p.log.success("Thanks for the star!");
-        } else {
+
+      if (!p.isCancel(wantsStar) && wantsStar) {
+        try {
+          const ok = await starRepo();
+          if (ok) {
+            p.log.success("Thanks for the star!");
+          } else {
+            p.log.info("Star us anytime: https://github.com/kyu1204/oh-my-harness");
+          }
+        } catch {
           p.log.info("Star us anytime: https://github.com/kyu1204/oh-my-harness");
         }
       }
     }
+  } catch {
+    // Star prompt errors must never abort init
   }
 
   p.outro("Happy coding!");

--- a/tests/unit/github-star.test.ts
+++ b/tests/unit/github-star.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  hasStarPromptBeenShown,
+  markStarPromptShown,
+} from "../../src/cli/github-star.js";
+
+describe("github-star state persistence", () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "omh-star-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("hasStarPromptBeenShown returns false when no state file", async () => {
+    expect(await hasStarPromptBeenShown()).toBe(false);
+  });
+
+  it("hasStarPromptBeenShown returns true after markStarPromptShown", async () => {
+    await markStarPromptShown();
+    expect(await hasStarPromptBeenShown()).toBe(true);
+  });
+
+  it("markStarPromptShown creates state file in ~/.omh/", async () => {
+    await markStarPromptShown();
+    const raw = await readFile(join(tmpDir, ".omh", "star-prompt.json"), "utf-8");
+    const state = JSON.parse(raw);
+    expect(state.prompted).toBe(true);
+  });
+});

--- a/tests/unit/github-star.test.ts
+++ b/tests/unit/github-star.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { mkdtemp, rm, readFile, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -42,6 +42,22 @@ describe("github-star state persistence", () => {
     const raw = await readFile(join(tmpDir, ".omh", "star-prompt.json"), "utf-8");
     const state = JSON.parse(raw);
     expect(state.prompted).toBe(true);
+  });
+
+  it("markStarPromptShown preserves existing state keys", async () => {
+    const statePath = join(tmpDir, ".omh", "star-prompt.json");
+    await mkdir(join(tmpDir, ".omh"), { recursive: true });
+    await writeFile(
+      statePath,
+      JSON.stringify({ prompted: false, dismissedAt: "2026-04-09T00:00:00Z" }, null, 2) + "\n",
+      "utf-8",
+    );
+
+    await markStarPromptShown();
+
+    const raw = await readFile(statePath, "utf-8");
+    const state = JSON.parse(raw);
+    expect(state).toEqual({ prompted: true, dismissedAt: "2026-04-09T00:00:00Z" });
   });
 
   it("markStarPromptShown is idempotent — calling twice still returns true", async () => {

--- a/tests/unit/github-star.test.ts
+++ b/tests/unit/github-star.test.ts
@@ -19,7 +19,12 @@ describe("github-star state persistence", () => {
   });
 
   afterEach(async () => {
-    process.env.HOME = originalHome;
+    // Safely restore HOME: avoid setting string "undefined"
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
     await rm(tmpDir, { recursive: true, force: true });
   });
 
@@ -37,5 +42,11 @@ describe("github-star state persistence", () => {
     const raw = await readFile(join(tmpDir, ".omh", "star-prompt.json"), "utf-8");
     const state = JSON.parse(raw);
     expect(state.prompted).toBe(true);
+  });
+
+  it("markStarPromptShown is idempotent — calling twice still returns true", async () => {
+    await markStarPromptShown();
+    await markStarPromptShown();
+    expect(await hasStarPromptBeenShown()).toBe(true);
   });
 });

--- a/tests/unit/nl-parse-intent.test.ts
+++ b/tests/unit/nl-parse-intent.test.ts
@@ -1,8 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { buildPresetSelectionPrompt, buildHarnessGenerationPrompt } from "../../src/nl/prompt-templates.js";
 import { parseNaturalLanguage, generateHarnessConfig } from "../../src/nl/parse-intent.js";
 import type { ClaudeRunner } from "../../src/nl/parse-intent.js";
 import yaml from "js-yaml";
+
+vi.mock("../../src/nl/config-store.js", () => ({
+  loadProviderConfig: vi.fn().mockResolvedValue(undefined),
+  hasProviderConfig: vi.fn().mockResolvedValue(false),
+  saveProviderConfig: vi.fn().mockResolvedValue(undefined),
+  getConfigDir: vi.fn().mockReturnValue("/tmp/omh-test"),
+}));
 
 const samplePresets = [
   {


### PR DESCRIPTION
## Summary
- `omh init` 마지막 스텝에 GitHub star 유도 prompt 추가
- `~/.omh/star-prompt.json`에 상태 저장 — 첫 설치 때만 표시
- Yes 선택 시 `gh api user/starred/kyu1204/oh-my-harness -X PUT`으로 star
- 브라우저 없이 `gh` CLI로 처리
- 테스트 버그 수정: `createDefaultRunner` 테스트가 실제 `~/.omh/config.json`에 의존하던 문제 → `vi.mock`으로 격리

## Test plan
- [x] `~/.omh/star-prompt.json` 없을 때 prompt 표시
- [x] prompt 표시 후 상태 저장 → 재실행 시 표시 안 됨
- [x] `markStarPromptShown`이 기존 config 키 보존
- [x] 전체 테스트 스위트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 초기화 흐름 종료 시 GitHub 저장소에 별표를 요청하는 프롬프트 추가
  * 한 번 표시된 프롬프트는 상태로 기록해 재표시 방지
  * 사용자가 동의하면 자동으로 저장소에 별표를 시도하고 결과를 안내

* **테스트**
  * 프롬프트 상태 저장 및 조회에 대한 단위 테스트 추가
  * 일부 테스트 환경 설정이 더 안정적으로 동작하도록 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->