### PR TITLE
docs: update README for v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ your-project/
 ├── CLAUDE.md                          # TDD rules, coding standards
 ├── harness.yaml                       # Your harness config (source of truth)
 └── .claude/
-    ├── settings.json                  # Hook configs, permissions
+    ├── settings.json                  # Hook configs, permissions, AI provider
     ├── hooks/
     │   ├── catalog-branch-guard.sh    # Blocks commits on merged branches
     │   ├── catalog-tdd-guard.sh       # Enforces test-first workflow
@@ -107,12 +107,24 @@ your-project/
                     │    trackable)       │
                     └────────┬────────────┘
                              │
-              ┌──────────────┼──────────────┐
-              ▼              ▼              ▼
-        ┌──────────┐  ┌──────────┐  ┌──────────────┐
-        │ CLAUDE.md│  │  Hooks   │  │ settings.json│
-        │ (rules)  │  │ (enforce)│  │ (permissions)│
-        └──────────┘  └──────────┘  └──────────────┘
+              ┌──────────────┼──────────────────────┐
+              ▼              ▼              ▼        ▼
+        ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
+        │CLAUDE.md │  │  Hooks   │  │settings. │  │   AI     │
+        │ (rules)  │  │(enforce) │  │  json    │  │ Providers│
+        │          │  │          │  │(perms)   │  │          │
+        └──────────┘  └──────────┘  └──────────┘  └──────────┘
+                                            │
+                    ┌───────────────────────┘
+                    │
+         ┌──────────▼──────────┐
+         │  nl/providers       │
+         ├─────────────────────┤
+         │ • Claude CLI        │ ← default
+         │ • Claude API        │
+         │ • OpenAI API        │
+         │ • Gemini API        │
+         └─────────────────────┘
 ```
 
 ### 🔍 Project Detector
@@ -136,6 +148,23 @@ oh-my-harness automatically detects your project type and injects accurate facts
 | 🔷 Scala | build.sbt | sbt test |
 | ⚡ Zig | build.zig | zig build test |
 
+### 🤖 AI Provider Setup
+
+oh-my-harness supports multiple AI providers for natural language mode:
+
+| Provider | Setup | Available Models | Default |
+|----------|-------|------------------|---------|
+| **Claude CLI** | `claude` command installed | Opus 4.6, Sonnet 4.6, Haiku 4.5 | ✓ |
+| **Claude API** | Set `ANTHROPIC_API_KEY` | Opus 4.6, Sonnet 4.6, Haiku 4.5 | Sonnet 4.6 |
+| **OpenAI API** | Set `OPENAI_API_KEY` | GPT-5.4, GPT-5.4-mini, GPT-5.4-nano, GPT-4.1, GPT-4.1-mini, o3, o4-mini | GPT-5.4 |
+| **Gemini API** | Set `GOOGLE_API_KEY` | Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite, Gemini 3.1 Pro Preview | Gemini 2.5 Pro |
+
+Configuration is saved to `~/.omh/config.json` and selected via interactive UI on first use:
+
+```bash
+omh init  # will prompt for AI provider selection and model choice
+```
+
 ---
 
 ## 🧱 Building Block Catalog
@@ -153,8 +182,14 @@ All enforcement is powered by **catalog blocks** — reusable, parameterized hoo
 | 🤫 `secret-file-guard` | security | Blocks edits to .env, credentials |
 | ✏️ `lint-on-save` | auto-fix | Auto-lint on file save |
 | 🎨 `format-on-save` | auto-fix | Auto-format on file save |
+| 🧪 `test-on-save` | auto-fix | Auto-run tests on file save |
 | 🔀 `auto-pr` | automation | Auto-create PR after push |
 | 🧪 `tdd-guard` | quality | Blocks source edits unless test modified first (JS/TS/Python) |
+| 🔒 `sql-guard` | security | Blocks dangerous SQL operations |
+| 🌳 `worktree-setup` | monorepo | Supports monorepo worktree patterns |
+| 🗜️ `compact-context` | maintenance | Re-injects context on session start |
+| 📋 `config-audit` | audit | Audit trail for config changes |
+| 🔔 `desktop-notify` | ux | Cross-platform desktop notifications |
 
 ### Usage in `harness.yaml`
 
@@ -190,7 +225,7 @@ hooks:
 
 ```bash
 # 🚀 Initialize
-omh init "your project description"      # NL-powered (requires Claude CLI)
+omh init "your project description"      # NL-powered (requires AI provider)
 omh init --preset nextjs fastapi          # Preset-based (instant)
 
 # 📋 Catalog
@@ -298,7 +333,7 @@ oh-my-harness/
 ├── bin/                    # CLI entry point
 ├── src/
 │   ├── catalog/
-│   │   ├── blocks/         # 11 building block definitions
+│   │   ├── blocks/         # 17 building block definitions
 │   │   ├── types.ts        # BuildingBlock, HookEntry schemas
 │   │   ├── registry.ts     # Block discovery & search
 │   │   ├── template-engine.ts # Handlebars rendering + applyDefaults
@@ -327,11 +362,21 @@ oh-my-harness/
 │   │   ├── project-detector.ts  # Deterministic project detection
 │   │   ├── types.ts             # ProjectFacts, Detector interface
 │   │   └── detectors/           # 14 language detectors
+│   ├── cli/
+│   │   ├── tui/            # Interactive provider & model selection
+│   │   └── provider-setup.ts # Provider configuration UI
 │   └── nl/
-│       ├── parse-intent.ts     # claude -p integration
-│       └── prompt-templates.ts # LLM prompt construction
+│       ├── provider-registry.ts # Multi-provider definitions
+│       ├── config-store.ts      # ~/.omh/config.json persistence
+│       ├── providers/           # Provider implementations
+│       │   ├── claude-cli.ts
+│       │   ├── claude-api.ts
+│       │   ├── openai-api.ts
+│       │   └── gemini-api.ts
+│       ├── parse-intent.ts      # LLM prompt integration
+│       └── prompt-templates.ts  # NL prompt construction
 ├── presets/                # Built-in preset definitions
-└── tests/                  # 745+ tests (unit + integration)
+└── tests/                  # 873+ tests (unit + integration)
 ```
 
 ---
@@ -339,7 +384,8 @@ oh-my-harness/
 ## 📦 Requirements
 
 - **Node.js** >= 20
-- **Claude CLI** (optional, for NL mode) — [Install guide](https://docs.anthropic.com/en/docs/claude-code)
+- **Claude CLI** (optional, for default NL mode) — [Install guide](https://docs.anthropic.com/en/docs/claude-code)
+- **API Keys** (optional, for Claude/OpenAI/Gemini API modes) — set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`
 
 ---
 
@@ -347,12 +393,15 @@ oh-my-harness/
 
 - [x] `npx oh-my-harness` — zero-install usage
 - [x] `omh sync` — regenerate from harness.yaml
-- [x] Building block catalog — 11 verified hook templates
+- [x] Building block catalog — 17 verified hook templates
 - [x] Project detector — 14 language auto-detection
 - [x] `omh test` — dry-run hook verification
 - [x] `omh stats` — TUI analytics dashboard (ink)
 - [x] Stateful hook logging — events.jsonl
 - [x] TDD Guard — enforce test-first workflow
+- [x] Multi-provider AI support — Claude API, OpenAI, Gemini
+- [x] Interactive model selection per provider
+- [x] GitHub star prompt — first-time only
 - [ ] Cursor (`.cursor/rules/`) emitter
 - [ ] Codex (`AGENTS.md`) emitter
 - [ ] GitHub Copilot emitter

--- a/README.md
+++ b/README.md
@@ -92,42 +92,31 @@ your-project/
 ## ⚙️ How It Works
 
 ```text
-                    ┌─────────────────────┐
-  "React + FastAPI  │                     │
-   TDD enforced"    │   claude -p (NL)    │
-  ─────────────────▶│   or --preset flag  │
-                    │                     │
-                    └────────┬────────────┘
-                             │
-                    ┌────────▼────────────┐
-                    │  Project Detector   │  ← Auto-detects language,
-                    │  (14 languages)     │    framework, package manager
-                    └────────┬────────────┘
-                             │
-                    ┌────────▼────────────┐
-                    │   harness.yaml      │  ← Source of truth
-                    │   (editable, git    │    (hooks + rules)
-                    │    trackable)       │
-                    └────────┬────────────┘
-                             │
-              ┌──────────────┼──────────────────────┐
-              ▼              ▼              ▼        ▼
-        ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
-        │CLAUDE.md │  │  Hooks   │  │settings. │  │   AI     │
-        │ (rules)  │  │(enforce) │  │  json    │  │ Providers│
-        │          │  │          │  │(perms)   │  │          │
-        └──────────┘  └──────────┘  └──────────┘  └──────────┘
-                                            │
-                    ┌───────────────────────┘
-                    │
-         ┌──────────▼──────────┐
-         │  nl/providers       │
-         ├─────────────────────┤
-         │ • Claude CLI        │ ← default
-         │ • Claude API        │
-         │ • OpenAI API        │
-         │ • Gemini API        │
-         └─────────────────────┘
+  ~/.omh/config.json   ┌─────────────────────┐
+  ┌────────────────┐   │                     │
+  │ • Claude CLI   │──▶│   NL Processing     │◀── "React + FastAPI
+  │ • Claude API   │   │   or --preset flag  │     TDD enforced"
+  │ • OpenAI API   │   │                     │
+  │ • Gemini API   │   └────────┬────────────┘
+  └────────────────┘            │
+   (global AI config)  ┌────────▼────────────┐
+                        │  Project Detector   │  ← Auto-detects language,
+                        │  (14 languages)     │    framework, package manager
+                        └────────┬────────────┘
+                                 │
+                        ┌────────▼────────────┐
+                        │   harness.yaml      │  ← Source of truth
+                        │   (editable, git    │    (hooks + rules)
+                        │    trackable)       │
+                        └────────┬────────────┘
+                                 │
+                  ┌──────────────┼──────────────┐
+                  ▼              ▼              ▼
+            ┌──────────┐  ┌──────────┐  ┌──────────┐
+            │CLAUDE.md │  │  Hooks   │  │settings. │
+            │ (rules)  │  │(enforce) │  │  json    │
+            │          │  │          │  │(perms)   │
+            └──────────┘  └──────────┘  └──────────┘
 ```
 
 ### 🔍 Project Detector

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ your-project/
   │ • OpenAI API   │   │                     │
   │ • Gemini API   │   └────────┬────────────┘
   └────────────────┘            │
-   (global AI config)  ┌────────▼────────────┐
+   (global AI config)   ┌────────▼────────────┐
                         │  Project Detector   │  ← Auto-detects language,
                         │  (14 languages)     │    framework, package manager
                         └────────┬────────────┘

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ omh stats         # TUI analytics dashboard
 ### 📁 What Gets Generated
 
 ```text
+~/.omh/
+└── config.json                        # AI provider config (global, not per-project)
+
 your-project/
 ├── CLAUDE.md                          # TDD rules, coding standards
 ├── harness.yaml                       # Your harness config (source of truth)
 └── .claude/
-    ├── settings.json                  # Hook configs, permissions, AI provider
+    ├── settings.json                  # Hook configs, permissions
     ├── hooks/
     │   ├── catalog-branch-guard.sh    # Blocks commits on merged branches
     │   ├── catalog-tdd-guard.sh       # Enforces test-first workflow


### PR DESCRIPTION
## Summary
- Multi-provider AI 지원 섹션 추가 (Claude API/CLI, OpenAI gpt-5.4, Gemini 2.5)
- 빌딩 블록 수 11→17개 업데이트 (7개 누락 블록 추가)
- 아키텍처 다이어그램에 nl/providers 레이어 추가
- 테스트 수 873+로 업데이트
- Roadmap: multi-provider AI, GitHub star prompt 완료 표시

## Test plan
- [ ] README 렌더링 확인 (GitHub 미리보기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)