### PR TITLE
fix: delete stale hook files on omh sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ your-project/
 ├── CLAUDE.md                          # TDD rules, coding standards
 ├── harness.yaml                       # Your harness config (source of truth)
 └── .claude/
-    ├── settings.json                  # Hook configs, permissions
+    ├── settings.json                  # Hook configs, permissions, AI provider
     ├── hooks/
     │   ├── catalog-branch-guard.sh    # Blocks commits on merged branches
     │   ├── catalog-tdd-guard.sh       # Enforces test-first workflow
@@ -107,12 +107,24 @@ your-project/
                     │    trackable)       │
                     └────────┬────────────┘
                              │
-              ┌──────────────┼──────────────┐
-              ▼              ▼              ▼
-        ┌──────────┐  ┌──────────┐  ┌──────────────┐
-        │ CLAUDE.md│  │  Hooks   │  │ settings.json│
-        │ (rules)  │  │ (enforce)│  │ (permissions)│
-        └──────────┘  └──────────┘  └──────────────┘
+              ┌──────────────┼──────────────────────┐
+              ▼              ▼              ▼        ▼
+        ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
+        │CLAUDE.md │  │  Hooks   │  │settings. │  │   AI     │
+        │ (rules)  │  │(enforce) │  │  json    │  │ Providers│
+        │          │  │          │  │(perms)   │  │          │
+        └──────────┘  └──────────┘  └──────────┘  └──────────┘
+                                            │
+                    ┌───────────────────────┘
+                    │
+         ┌──────────▼──────────┐
+         │  nl/providers       │
+         ├─────────────────────┤
+         │ • Claude CLI        │ ← default
+         │ • Claude API        │
+         │ • OpenAI API        │
+         │ • Gemini API        │
+         └─────────────────────┘
 ```
 
 ### 🔍 Project Detector
@@ -136,6 +148,23 @@ oh-my-harness automatically detects your project type and injects accurate facts
 | 🔷 Scala | build.sbt | sbt test |
 | ⚡ Zig | build.zig | zig build test |
 
+### 🤖 AI Provider Setup
+
+oh-my-harness supports multiple AI providers for natural language mode:
+
+| Provider | Setup | Available Models | Default |
+|----------|-------|------------------|---------|
+| **Claude CLI** | `claude` command installed | Opus 4.6, Sonnet 4.6, Haiku 4.5 | ✓ |
+| **Claude API** | Set `ANTHROPIC_API_KEY` | Opus 4.6, Sonnet 4.6, Haiku 4.5 | Sonnet 4.6 |
+| **OpenAI API** | Set `OPENAI_API_KEY` | GPT-5.4, GPT-5.4-mini, GPT-5.4-nano, GPT-4.1, GPT-4.1-mini, o3, o4-mini | GPT-5.4 |
+| **Gemini API** | Set `GOOGLE_API_KEY` | Gemini 2.5 Pro, Gemini 2.5 Flash, Gemini 2.5 Flash Lite, Gemini 3.1 Pro Preview | Gemini 2.5 Pro |
+
+Configuration is saved to `~/.omh/config.json` and selected via interactive UI on first use:
+
+```bash
+omh init  # will prompt for AI provider selection and model choice
+```
+
 ---
 
 ## 🧱 Building Block Catalog
@@ -153,8 +182,14 @@ All enforcement is powered by **catalog blocks** — reusable, parameterized hoo
 | 🤫 `secret-file-guard` | security | Blocks edits to .env, credentials |
 | ✏️ `lint-on-save` | auto-fix | Auto-lint on file save |
 | 🎨 `format-on-save` | auto-fix | Auto-format on file save |
+| 🧪 `test-on-save` | auto-fix | Auto-run tests on file save |
 | 🔀 `auto-pr` | automation | Auto-create PR after push |
 | 🧪 `tdd-guard` | quality | Blocks source edits unless test modified first (JS/TS/Python) |
+| 🔒 `sql-guard` | security | Blocks dangerous SQL operations |
+| 🌳 `worktree-setup` | monorepo | Supports monorepo worktree patterns |
+| 🗜️ `compact-context` | maintenance | Re-injects context on session start |
+| 📋 `config-audit` | audit | Audit trail for config changes |
+| 🔔 `desktop-notify` | ux | Cross-platform desktop notifications |
 
 ### Usage in `harness.yaml`
 
@@ -190,7 +225,7 @@ hooks:
 
 ```bash
 # 🚀 Initialize
-omh init "your project description"      # NL-powered (requires Claude CLI)
+omh init "your project description"      # NL-powered (requires AI provider)
 omh init --preset nextjs fastapi          # Preset-based (instant)
 
 # 📋 Catalog
@@ -298,7 +333,7 @@ oh-my-harness/
 ├── bin/                    # CLI entry point
 ├── src/
 │   ├── catalog/
-│   │   ├── blocks/         # 11 building block definitions
+│   │   ├── blocks/         # 17 building block definitions
 │   │   ├── types.ts        # BuildingBlock, HookEntry schemas
 │   │   ├── registry.ts     # Block discovery & search
 │   │   ├── template-engine.ts # Handlebars rendering + applyDefaults
@@ -327,11 +362,21 @@ oh-my-harness/
 │   │   ├── project-detector.ts  # Deterministic project detection
 │   │   ├── types.ts             # ProjectFacts, Detector interface
 │   │   └── detectors/           # 14 language detectors
+│   ├── cli/
+│   │   ├── tui/            # Interactive provider & model selection
+│   │   └── provider-setup.ts # Provider configuration UI
 │   └── nl/
-│       ├── parse-intent.ts     # claude -p integration
-│       └── prompt-templates.ts # LLM prompt construction
+│       ├── provider-registry.ts # Multi-provider definitions
+│       ├── config-store.ts      # ~/.omh/config.json persistence
+│       ├── providers/           # Provider implementations
+│       │   ├── claude-cli.ts
+│       │   ├── claude-api.ts
+│       │   ├── openai-api.ts
+│       │   └── gemini-api.ts
+│       ├── parse-intent.ts      # LLM prompt integration
+│       └── prompt-templates.ts  # NL prompt construction
 ├── presets/                # Built-in preset definitions
-└── tests/                  # 745+ tests (unit + integration)
+└── tests/                  # 873+ tests (unit + integration)
 ```
 
 ---
@@ -339,7 +384,8 @@ oh-my-harness/
 ## 📦 Requirements
 
 - **Node.js** >= 20
-- **Claude CLI** (optional, for NL mode) — [Install guide](https://docs.anthropic.com/en/docs/claude-code)
+- **Claude CLI** (optional, for default NL mode) — [Install guide](https://docs.anthropic.com/en/docs/claude-code)
+- **API Keys** (optional, for Claude/OpenAI/Gemini API modes) — set `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`
 
 ---
 
@@ -347,12 +393,15 @@ oh-my-harness/
 
 - [x] `npx oh-my-harness` — zero-install usage
 - [x] `omh sync` — regenerate from harness.yaml
-- [x] Building block catalog — 11 verified hook templates
+- [x] Building block catalog — 17 verified hook templates
 - [x] Project detector — 14 language auto-detection
 - [x] `omh test` — dry-run hook verification
 - [x] `omh stats` — TUI analytics dashboard (ink)
 - [x] Stateful hook logging — events.jsonl
 - [x] TDD Guard — enforce test-first workflow
+- [x] Multi-provider AI support — Claude API, OpenAI, Gemini
+- [x] Interactive model selection per provider
+- [x] GitHub star prompt — first-time only
 - [ ] Cursor (`.cursor/rules/`) emitter
 - [ ] Codex (`AGENTS.md`) emitter
 - [ ] GitHub Copilot emitter

--- a/README.md
+++ b/README.md
@@ -92,42 +92,31 @@ your-project/
 ## ⚙️ How It Works
 
 ```text
-                    ┌─────────────────────┐
-  "React + FastAPI  │                     │
-   TDD enforced"    │   claude -p (NL)    │
-  ─────────────────▶│   or --preset flag  │
-                    │                     │
-                    └────────┬────────────┘
-                             │
-                    ┌────────▼────────────┐
-                    │  Project Detector   │  ← Auto-detects language,
-                    │  (14 languages)     │    framework, package manager
-                    └────────┬────────────┘
-                             │
-                    ┌────────▼────────────┐
-                    │   harness.yaml      │  ← Source of truth
-                    │   (editable, git    │    (hooks + rules)
-                    │    trackable)       │
-                    └────────┬────────────┘
-                             │
-              ┌──────────────┼──────────────────────┐
-              ▼              ▼              ▼        ▼
-        ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐
-        │CLAUDE.md │  │  Hooks   │  │settings. │  │   AI     │
-        │ (rules)  │  │(enforce) │  │  json    │  │ Providers│
-        │          │  │          │  │(perms)   │  │          │
-        └──────────┘  └──────────┘  └──────────┘  └──────────┘
-                                            │
-                    ┌───────────────────────┘
-                    │
-         ┌──────────▼──────────┐
-         │  nl/providers       │
-         ├─────────────────────┤
-         │ • Claude CLI        │ ← default
-         │ • Claude API        │
-         │ • OpenAI API        │
-         │ • Gemini API        │
-         └─────────────────────┘
+  ~/.omh/config.json   ┌─────────────────────┐
+  ┌────────────────┐   │                     │
+  │ • Claude CLI   │──▶│   NL Processing     │◀── "React + FastAPI
+  │ • Claude API   │   │   or --preset flag  │     TDD enforced"
+  │ • OpenAI API   │   │                     │
+  │ • Gemini API   │   └────────┬────────────┘
+  └────────────────┘            │
+   (global AI config)  ┌────────▼────────────┐
+                        │  Project Detector   │  ← Auto-detects language,
+                        │  (14 languages)     │    framework, package manager
+                        └────────┬────────────┘
+                                 │
+                        ┌────────▼────────────┐
+                        │   harness.yaml      │  ← Source of truth
+                        │   (editable, git    │    (hooks + rules)
+                        │    trackable)       │
+                        └────────┬────────────┘
+                                 │
+                  ┌──────────────┼──────────────┐
+                  ▼              ▼              ▼
+            ┌──────────┐  ┌──────────┐  ┌──────────┐
+            │CLAUDE.md │  │  Hooks   │  │settings. │
+            │ (rules)  │  │(enforce) │  │  json    │
+            │          │  │          │  │(perms)   │
+            └──────────┘  └──────────┘  └──────────┘
 ```
 
 ### 🔍 Project Detector

--- a/README.md
+++ b/README.md
@@ -339,6 +339,8 @@ oh-my-harness/
 │   │   ├── harness-tester.ts  # Hook simulation engine
 │   │   ├── event-logger.ts    # events.jsonl read/write/stats
 │   │   ├── event-verifier.ts  # Event-based verification
+│   │   ├── tui/               # Interactive provider & model selection
+│   │   ├── provider-setup.ts  # Provider configuration UI
 │   │   └── tool-checker.ts    # Command executable checks
 │   ├── core/
 │   │   ├── harness-schema.ts   # harness.yaml Zod schema
@@ -354,9 +356,6 @@ oh-my-harness/
 │   │   ├── project-detector.ts  # Deterministic project detection
 │   │   ├── types.ts             # ProjectFacts, Detector interface
 │   │   └── detectors/           # 14 language detectors
-│   ├── cli/
-│   │   ├── tui/            # Interactive provider & model selection
-│   │   └── provider-setup.ts # Provider configuration UI
 │   └── nl/
 │       ├── provider-registry.ts # Multi-provider definitions
 │       ├── config-store.ts      # ~/.omh/config.json persistence

--- a/README.md
+++ b/README.md
@@ -65,11 +65,14 @@ omh stats         # TUI analytics dashboard
 ### 📁 What Gets Generated
 
 ```text
+~/.omh/
+└── config.json                        # AI provider config (global, not per-project)
+
 your-project/
 ├── CLAUDE.md                          # TDD rules, coding standards
 ├── harness.yaml                       # Your harness config (source of truth)
 └── .claude/
-    ├── settings.json                  # Hook configs, permissions, AI provider
+    ├── settings.json                  # Hook configs, permissions
     ├── hooks/
     │   ├── catalog-branch-guard.sh    # Blocks commits on merged branches
     │   ├── catalog-tdd-guard.sh       # Enforces test-first workflow

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile, chmod } from "node:fs/promises";
+import { mkdir, writeFile, chmod, readFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
 
@@ -68,11 +68,30 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
     hooks.map((h) => ({ ...h, event })),
   );
 
-  if (allHooks.length === 0) {
-    return { hooksConfig: {}, generatedFiles: [] };
+  await mkdir(hooksDir, { recursive: true });
+
+  // Read previous manifest to clean up stale hook files
+  const manifestPath = join(hooksDir, "oh-my-harness-manifest.json");
+  let previousHooks: string[] = [];
+  try {
+    const manifestRaw = await readFile(manifestPath, "utf8");
+    const manifest = JSON.parse(manifestRaw) as { hooks?: string[] };
+    previousHooks = manifest.hooks ?? [];
+  } catch {
+    // No prior manifest — nothing to clean up
   }
 
-  await mkdir(hooksDir, { recursive: true });
+  if (allHooks.length === 0) {
+    // Remove all previously generated hooks
+    for (const name of previousHooks) {
+      try {
+        await unlink(join(hooksDir, name));
+      } catch {
+        // Already gone — ignore
+      }
+    }
+    return { hooksConfig: {}, generatedFiles: [] };
+  }
 
   const generatedFiles: string[] = [];
   const hooksConfig: Record<string, Array<{ matcher: string; hooks: HookCommand[] }>> = {};
@@ -108,12 +127,23 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
     hooksConfig[hook.event].push(entry);
   }
 
+  // Remove stale hook files from previous sync that are no longer generated
+  const currentNames = new Set(generatedFiles.map((f) => f.split("/").pop() as string));
+  for (const name of previousHooks) {
+    if (!currentNames.has(name)) {
+      try {
+        await unlink(join(hooksDir, name));
+      } catch {
+        // Already gone — ignore
+      }
+    }
+  }
+
   // Write manifest
   const manifest = {
     generatedAt: new Date().toISOString(),
     hooks: generatedFiles.map((f) => f.split("/").pop() as string),
   };
-  const manifestPath = join(hooksDir, "oh-my-harness-manifest.json");
   await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
 
   return { hooksConfig, generatedFiles };

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -51,6 +51,46 @@ export interface HooksOutput {
   generatedFiles: string[];
 }
 
+interface HookManifest {
+  generatedAt: string;
+  hooks: string[];
+}
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error;
+}
+
+async function readPreviousHookNames(manifestPath: string): Promise<string[]> {
+  try {
+    const manifestRaw = await readFile(manifestPath, "utf8");
+    const manifest = JSON.parse(manifestRaw) as { hooks?: string[] };
+    return manifest.hooks ?? [];
+  } catch (err) {
+    if (isErrnoException(err) && err.code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+}
+
+async function unlinkIfPresent(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (err) {
+    if (!isErrnoException(err) || err.code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+async function writeHookManifest(manifestPath: string, hooks: string[]): Promise<void> {
+  const manifest: HookManifest = {
+    generatedAt: new Date().toISOString(),
+    hooks,
+  };
+  await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
+}
+
 export async function generateHooks(options: GenerateHooksOptions): Promise<HooksOutput> {
   const { projectDir, config } = options;
   const hooksDir = join(projectDir, ".claude/hooks");
@@ -72,24 +112,14 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
 
   // Read previous manifest to clean up stale hook files
   const manifestPath = join(hooksDir, "oh-my-harness-manifest.json");
-  let previousHooks: string[] = [];
-  try {
-    const manifestRaw = await readFile(manifestPath, "utf8");
-    const manifest = JSON.parse(manifestRaw) as { hooks?: string[] };
-    previousHooks = manifest.hooks ?? [];
-  } catch {
-    // No prior manifest — nothing to clean up
-  }
+  const previousHooks = await readPreviousHookNames(manifestPath);
 
   if (allHooks.length === 0) {
     // Remove all previously generated hooks
     for (const name of previousHooks) {
-      try {
-        await unlink(join(hooksDir, name));
-      } catch {
-        // Already gone — ignore
-      }
+      await unlinkIfPresent(join(hooksDir, name));
     }
+    await writeHookManifest(manifestPath, []);
     return { hooksConfig: {}, generatedFiles: [] };
   }
 
@@ -131,20 +161,14 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
   const currentNames = new Set(generatedFiles.map((f) => f.split("/").pop() as string));
   for (const name of previousHooks) {
     if (!currentNames.has(name)) {
-      try {
-        await unlink(join(hooksDir, name));
-      } catch {
-        // Already gone — ignore
-      }
+      await unlinkIfPresent(join(hooksDir, name));
     }
   }
 
-  // Write manifest
-  const manifest = {
-    generatedAt: new Date().toISOString(),
-    hooks: generatedFiles.map((f) => f.split("/").pop() as string),
-  };
-  await writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8");
+  await writeHookManifest(
+    manifestPath,
+    generatedFiles.map((f) => f.split("/").pop() as string),
+  );
 
   return { hooksConfig, generatedFiles };
 }

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -102,6 +102,34 @@ describe("generateHooks", () => {
     ]);
   });
 
+  it("writes an empty manifest after removing all previously generated hooks", async () => {
+    await generateHooks({
+      projectDir,
+      config: makeMergedConfig({
+        hooks: {
+          preToolUse: [{ id: "command-guard", matcher: "Bash", inline: "#!/bin/bash\nexit 0" }],
+          postToolUse: [],
+        },
+      }),
+    });
+
+    const result = await generateHooks({ projectDir, config: makeMergedConfig() });
+    const manifestPath = join(projectDir, ".claude/hooks/oh-my-harness-manifest.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+    expect(result).toEqual({ hooksConfig: {}, generatedFiles: [] });
+    expect(manifest.hooks).toEqual([]);
+  });
+
+  it("throws when an existing hooks manifest cannot be parsed", async () => {
+    const hooksDir = join(projectDir, ".claude/hooks");
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(hooksDir, { recursive: true });
+    await writeFile(join(hooksDir, "oh-my-harness-manifest.json"), "{not-json", "utf8");
+
+    await expect(generateHooks({ projectDir, config: makeMergedConfig() })).rejects.toThrow();
+  });
+
   it("writes manifest file tracking generated hooks", async () => {
     const config = makeMergedConfig({
       hooks: {

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -291,6 +291,89 @@ describe("wrapWithLogger", () => {
   });
 });
 
+describe("generateHooks — stale hook cleanup on sync", () => {
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "oh-my-harness-cleanup-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("removes stale hook file when hook is deleted from harness.yaml", async () => {
+    // First sync: tdd-guard + branch-guard
+    const configBefore = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "tdd-guard", matcher: "Bash", inline: "#!/bin/bash\nexit 0" },
+          { id: "branch-guard", matcher: "Bash", inline: "#!/bin/bash\nexit 0" },
+        ],
+        postToolUse: [],
+      },
+    });
+    await generateHooks({ projectDir, config: configBefore });
+
+    const tddScript = join(projectDir, ".claude/hooks/tdd-guard.sh");
+    const branchScript = join(projectDir, ".claude/hooks/branch-guard.sh");
+
+    // Verify both files exist
+    await expect(stat(tddScript)).resolves.toBeDefined();
+    await expect(stat(branchScript)).resolves.toBeDefined();
+
+    // Second sync: tdd-guard removed
+    const configAfter = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "branch-guard", matcher: "Bash", inline: "#!/bin/bash\nexit 0" },
+        ],
+        postToolUse: [],
+      },
+    });
+    await generateHooks({ projectDir, config: configAfter });
+
+    // tdd-guard.sh must be deleted
+    await expect(stat(tddScript)).rejects.toThrow();
+    // branch-guard.sh must remain
+    await expect(stat(branchScript)).resolves.toBeDefined();
+  });
+
+  it("removes all stale hooks when all hooks are removed", async () => {
+    const configBefore = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "tdd-guard", matcher: "Bash", inline: "#!/bin/bash\nexit 0" },
+        ],
+        postToolUse: [],
+      },
+    });
+    await generateHooks({ projectDir, config: configBefore });
+
+    const tddScript = join(projectDir, ".claude/hooks/tdd-guard.sh");
+    await expect(stat(tddScript)).resolves.toBeDefined();
+
+    // Second sync: no hooks
+    const configAfter = makeMergedConfig();
+    await generateHooks({ projectDir, config: configAfter });
+
+    await expect(stat(tddScript)).rejects.toThrow();
+  });
+
+  it("does not error when there is no prior manifest", async () => {
+    // First sync with no prior manifest — should work cleanly
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "branch-guard", matcher: "Bash", inline: "#!/bin/bash\nexit 0" },
+        ],
+        postToolUse: [],
+      },
+    });
+    await expect(generateHooks({ projectDir, config })).resolves.toBeDefined();
+  });
+});
+
 describe("generateHooks — extended events", () => {
   let projectDir: string;
 


### PR DESCRIPTION
## Summary
- `omh sync`로 `harness.yaml`에서 훅을 제거했을 때 `.sh` 파일이 고아(orphan)로 남던 버그 수정
- `generateHooks`가 sync 시 이전 manifest를 읽어 현재 목록에 없는 구 hook 파일을 자동 삭제
- 훅이 전부 제거되는 경우도 정상 처리

## Test plan
- [x] `removes stale hook file when hook is deleted from harness.yaml`
- [x] `removes all stale hooks when all hooks are removed`
- [x] `does not error when there is no prior manifest`
- [x] 전체 831개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 여러 AI 공급자 지원 (Claude, OpenAI, Gemini)
  * 전역 AI 공급자 설정 파일 추가
  * 대화형 초기화 프롬프트를 통한 모델 선택

* **개선 사항**
  * 훅 파일 동기화 시 자동 정리 메커니즘 개선
  * AI 공급자 설정 및 사용 가이드 확장
  * 빌딩 블록 카탈로그 확대

* **Tests**
  * 훅 정리 동작 검증 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->