### PR TITLE
fix: prevent TOCTOU race condition in tdd-guard edit-history writes

### DIFF
--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -46,14 +46,17 @@ SRC_RE='{{{srcPattern}}}'
 TEST_RE="\${TEST_RE//\\\\\\\\/\\\\}"
 SRC_RE="\${SRC_RE//\\\\\\\\/\\\\}"
 if [[ "\$FILE_PATH" =~ \$TEST_RE ]]; then
-  # 테스트 파일 수정 → 기록 + 통과
-  if [[ ! -f "\$HISTORY_FILE" ]]; then
-    echo '{"edits":[]}' > "\$HISTORY_FILE"
-  fi
-  UPDATED=$(jq --arg f "\$FILE_PATH" '.edits += [$f] | .edits |= unique' "\$HISTORY_FILE" 2>/dev/null) || true
-  if [[ -n "\$UPDATED" ]]; then
-    echo "\$UPDATED" > "\$HISTORY_FILE"
-  fi
+  # 테스트 파일 수정 → 기록 + 통과 (flock으로 원자적 읽기/쓰기)
+  (
+    flock -x 200
+    if [[ ! -f "\$HISTORY_FILE" ]]; then
+      echo '{"edits":[]}' > "\$HISTORY_FILE"
+    fi
+    UPDATED=$(jq --arg f "\$FILE_PATH" '.edits += [$f] | .edits |= unique' "\$HISTORY_FILE" 2>/dev/null) || true
+    if [[ -n "\$UPDATED" ]]; then
+      echo "\$UPDATED" > "\$HISTORY_FILE"
+    fi
+  ) 200>"\$HISTORY_FILE.lock"
   exit 0
 fi
 
@@ -72,16 +75,27 @@ if [[ ! -f "\$HISTORY_FILE" ]]; then
   exit 0
 fi
 
-# edit-history에서 테스트 파일 검색
-if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
-  # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
-  UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
-    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_"))) | not)]
-    | .edits += [$f] | .edits |= unique
-  ' "\$HISTORY_FILE" 2>/dev/null) || true
-  if [[ -n "\$UPDATED" ]]; then
-    echo "\$UPDATED" > "\$HISTORY_FILE"
-  fi
+# edit-history에서 테스트 파일 검색 (flock으로 원자적 읽기/쓰기)
+DECISION=$(
+  (
+    flock -x 200
+    if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
+      # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
+      UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
+        .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_"))) | not)]
+        | .edits += [$f] | .edits |= unique
+      ' "\$HISTORY_FILE" 2>/dev/null) || true
+      if [[ -n "\$UPDATED" ]]; then
+        echo "\$UPDATED" > "\$HISTORY_FILE"
+      fi
+      echo "allow"
+    else
+      echo "block"
+    fi
+  ) 200>"\$HISTORY_FILE.lock"
+)
+
+if [[ "\$DECISION" == "allow" ]]; then
   exit 0
 fi
 

--- a/tests/unit/tdd-guard.test.ts
+++ b/tests/unit/tdd-guard.test.ts
@@ -74,4 +74,12 @@ describe("tddGuard block", () => {
     expect(tddGuard.template).toContain("{{testPattern}}");
     expect(tddGuard.template).toContain("{{srcPattern}}");
   });
+
+  it("generated script uses flock for atomic read-write", () => {
+    // Two concurrent hook processes must not overwrite each other's writes.
+    // The script must use flock (file locking) around the jq read/write operations.
+    expect(tddGuard.template).toMatch(/flock/);
+    // The lock file descriptor redirect pattern: 200> or similar fd redirect
+    expect(tddGuard.template).toMatch(/\d+>.*\.lock/);
+  });
 });


### PR DESCRIPTION
## Summary

- Identified TOCTOU race condition in `tdd-guard.ts` bash template where two concurrent hook processes could read-then-write `edit-history.json` simultaneously, with one overwriting the other's update
- Added `flock -x 200` file locking around all jq read/write operations using `200>"$HISTORY_FILE.lock"` pattern, covering both the test-file recording path and the source-file allow/block decision path
- Refactored the source-file check to capture the allow/block decision from inside the locked subshell so the script correctly exits 0 for allowed edits

## Test plan

- [x] Added test: `"generated script uses flock for atomic read-write"` — verifies template contains `flock` and the `\d+>.*\.lock` fd redirect pattern
- [x] Confirmed new test failed before implementation
- [x] Confirmed all 15 `tdd-guard.test.ts` tests pass after implementation
- [x] Full test suite: 88 test files, 871 tests all pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * TDD 가드 블록의 편집 이력 파일에 대한 동시 접근 시 데이터 일관성을 보장하도록 개선했습니다.

* **테스트**
  * 파일 잠금을 통한 원자적 작업이 올바르게 실행되는지 검증하는 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->