### PR TITLE
fix: resolve hook id collision using numeric suffix

### DIFF
--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -85,10 +85,13 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
 
     const safeId = hook.id.replace(/[^a-zA-Z0-9_-]/g, "");
     let scriptName = `${safeId}.sh`;
-    // Prevent collisions when different events share the same hook.id
+    // Prevent collisions within the same event using numeric suffix
     if (usedScriptNames.has(scriptName)) {
-      const safeEvent = hook.event.replace(/[^a-zA-Z0-9_-]/g, "").toLowerCase();
-      scriptName = `${safeEvent}-${safeId}.sh`;
+      let counter = 1;
+      while (usedScriptNames.has(`${safeId}-${counter}.sh`)) {
+        counter++;
+      }
+      scriptName = `${safeId}-${counter}.sh`;
     }
     usedScriptNames.add(scriptName);
 

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -132,7 +132,7 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
       continue;
     }
 
-    const safeId = hook.id.replace(/[^a-zA-Z0-9_-]/g, "");
+    const safeId = hook.id.replace(/[^a-zA-Z0-9_-]/g, "") || "hook";
     let scriptName = `${safeId}.sh`;
     // Prevent collisions within the same event using numeric suffix
     if (usedScriptNames.has(scriptName)) {

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -228,6 +228,43 @@ describe("generateHooks", () => {
     expect(content).toContain("_log_event");
     expect(content).toContain("EXIT");
   });
+
+  it("avoids file collision when two hook ids sanitize to the same name in same event", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "my.hook", matcher: "Bash", inline: "#!/bin/bash\necho first" },
+          { id: "myhook", matcher: "Edit|Write", inline: "#!/bin/bash\necho second" },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+
+    // Both hooks should be generated as separate files
+    expect(result.generatedFiles).toHaveLength(2);
+
+    // Check that files exist and have different names
+    const file1 = join(projectDir, ".claude/hooks/myhook.sh");
+    const file2 = join(projectDir, ".claude/hooks/myhook-1.sh");
+
+    const content1 = await readFile(file1, "utf8");
+    const content2 = await readFile(file2, "utf8");
+
+    expect(content1).toContain("echo first");
+    expect(content2).toContain("echo second");
+
+    // Both files should be in generatedFiles and hooksConfig
+    expect(result.generatedFiles).toContain(file1);
+    expect(result.generatedFiles).toContain(file2);
+
+    // Check hooksConfig contains both hooks
+    expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
+    const commands = result.hooksConfig["PreToolUse"].map(h => h.hooks[0].command);
+    expect(commands).toContain("bash .claude/hooks/myhook.sh");
+    expect(commands).toContain("bash .claude/hooks/myhook-1.sh");
+  });
 });
 
 describe("wrapWithLogger", () => {

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -198,6 +198,30 @@ describe("generateHooks", () => {
     expect(content).toContain("exit 0");
   });
 
+  it("falls back to a safe default name when hook.id sanitizes to empty", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "!!!", matcher: "Bash", inline: "#!/bin/bash\necho first" },
+          { id: "...", matcher: "Edit|Write", inline: "#!/bin/bash\necho second" },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+
+    const file1 = join(projectDir, ".claude/hooks/hook.sh");
+    const file2 = join(projectDir, ".claude/hooks/hook-1.sh");
+
+    expect(result.generatedFiles).toContain(file1);
+    expect(result.generatedFiles).toContain(file2);
+    expect(result.hooksConfig["PreToolUse"]).toEqual([
+      { matcher: "Bash", hooks: [{ type: "command", command: "bash .claude/hooks/hook.sh" }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash .claude/hooks/hook-1.sh" }] },
+    ]);
+  });
+
   it("does not register hooks without inline content in hooksConfig", async () => {
     const config = makeMergedConfig({
       hooks: {
@@ -292,6 +316,33 @@ describe("generateHooks", () => {
     const commands = result.hooksConfig["PreToolUse"].map(h => h.hooks[0].command);
     expect(commands).toContain("bash .claude/hooks/myhook.sh");
     expect(commands).toContain("bash .claude/hooks/myhook-1.sh");
+  });
+
+  it("avoids file collision when same hook id exists in different events", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "myhook", matcher: "Bash", inline: "#!/bin/bash\necho pre" },
+        ],
+        postToolUse: [
+          { id: "myhook", matcher: "Edit|Write", inline: "#!/bin/bash\necho post" },
+        ],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+
+    const file1 = join(projectDir, ".claude/hooks/myhook.sh");
+    const file2 = join(projectDir, ".claude/hooks/myhook-1.sh");
+
+    expect(result.generatedFiles).toContain(file1);
+    expect(result.generatedFiles).toContain(file2);
+    expect(result.hooksConfig["PreToolUse"]).toEqual([
+      { matcher: "Bash", hooks: [{ type: "command", command: "bash .claude/hooks/myhook.sh" }] },
+    ]);
+    expect(result.hooksConfig["PostToolUse"]).toEqual([
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash .claude/hooks/myhook-1.sh" }] },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes hook id collision bug where different sanitized ids produce the same filename within the same event, causing file overwrites.

- When hook ids like "my.hook" and "myhook" both sanitize to "myhook.sh", the numeric suffix approach (myhook-1.sh, myhook-2.sh) prevents overwrites
- Replaces the previous event-prefix logic which only worked across different events
- Adds comprehensive test case validating the fix

## Test plan
- All existing hook generator tests pass (23 tests)
- New test verifies collision detection within same event:
  - Two hooks with sanitized name collision generate separate files
  - Both files contain correct content
  - Both appear in hooksConfig with correct commands
- Manual verification: npm test hooks-generator.test.ts passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Hook 스크립트 생성 시 파일명 충돌 처리 개선: 동일한 기본 이름이 이미 존재할 경우 가장 작은 숫자 접미사를 찾아 고유한 파일명으로 생성하여 기존 파일을 덮어쓰지 않도록 방지합니다.

* **테스트**
  * 동일한 이름으로 정규화되는 Hook 시나리오에 대한 단위 테스트 추가: 서로 다른 두 Hook이 같은 기본 이름으로 정규화될 때도 각각 별도 스크립트와 구성 항목이 생성되는지 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->