### PR TITLE
fix: use relative paths for catalog hook commands

### DIFF
--- a/src/catalog/converter.ts
+++ b/src/catalog/converter.ts
@@ -1,4 +1,3 @@
-import path from "path";
 import type { HookEntry } from "./types.js";
 import type { CatalogRegistry } from "./registry.js";
 import { renderTemplate, validateParams, applyDefaults } from "./template-engine.js";
@@ -52,7 +51,7 @@ export async function convertHookEntries(
     const count = blockInstanceCount.get(entry.block) ?? 0;
     blockInstanceCount.set(entry.block, count + 1);
     const scriptName = count === 0 ? `${entry.block}.sh` : `${entry.block}-${count}.sh`;
-    const scriptPath = path.join(projectDir, ".claude", "hooks", scriptName);
+    const scriptPath = `.claude/hooks/${scriptName}`;
     scripts.set(scriptPath, scriptContent);
 
     const hookEntry: HookConfigEntry = {

--- a/src/catalog/converter.ts
+++ b/src/catalog/converter.ts
@@ -17,7 +17,7 @@ export interface ConvertResult {
 export async function convertHookEntries(
   entries: HookEntry[],
   registry: CatalogRegistry,
-  projectDir: string,
+  _projectDir: string,
 ): Promise<ConvertResult> {
   const hooksConfig: Record<string, HookConfigEntry[]> = {};
   const scripts: Map<string, string> = new Map();

--- a/tests/unit/catalog-converter.test.ts
+++ b/tests/unit/catalog-converter.test.ts
@@ -136,6 +136,22 @@ describe("convertHookEntries", () => {
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(1);
   });
 
+  it("catalog hook commands use relative paths", async () => {
+    registry.register(makeBlock({ id: "tdd-guard", event: "PreToolUse", matcher: "Bash" }));
+    const entries: HookEntry[] = [{ block: "tdd-guard", params: {} }];
+
+    const result = await convertHookEntries(entries, registry, projectDir);
+
+    expect(result.errors).toHaveLength(0);
+    const command = result.hooksConfig["PreToolUse"][0].command;
+    expect(command).not.toContain(projectDir);
+    expect(command).toBe(".claude/hooks/tdd-guard.sh");
+
+    // scripts map key should also use relative path
+    const scriptKeys = [...result.scripts.keys()];
+    expect(scriptKeys[0]).toBe(".claude/hooks/tdd-guard.sh");
+  });
+
   it("allows duplicate block ids with different params (multi-instance)", async () => {
     registry.register(
       makeBlock({


### PR DESCRIPTION
## Summary
- `convertHookEntries` in `src/catalog/converter.ts` was building hook command paths using `path.join(projectDir, ".claude", "hooks", scriptName)`, producing absolute paths like `/Users/minkyu/project/.claude/hooks/tdd-guard.sh`
- Absolute paths break hooks when a project is moved to a different directory or machine
- Changed to use relative paths `.claude/hooks/<name>.sh`, consistent with how `src/generators/hooks.ts` already generates hook commands

## Test plan
- [x] Added test "catalog hook commands use relative paths" that asserts the command does not contain `projectDir` and equals `.claude/hooks/tdd-guard.sh`
- [x] Confirmed test failed before fix, passes after
- [x] All 871 tests pass across 88 test files (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩토링**
  * 후크 스크립트 경로 생성 로직을 간소화해 경로가 프로젝트별 절대 경로가 아닌 일관된 상대 경로로 생성되도록 변경하여 안정성과 일관성을 향상시켰습니다.

* **테스트**
  * 상대 경로로 생성되는 스크립트 경로의 정확성을 검증하는 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->