### PR TITLE
fix: track managed permissions to prevent monotonic growth

### DIFF
--- a/src/generators/settings.ts
+++ b/src/generators/settings.ts
@@ -23,21 +23,33 @@ export async function generateSettings(options: GenerateSettingsOptions): Promis
     // File doesn't exist or is invalid JSON — start fresh
   }
 
-  // Deep merge permissions: preserve existing, add managed entries
+  // Deep merge permissions: preserve user-added, replace managed entries
   const existingPermissions = (existing.permissions ?? {}) as {
     allow?: string[];
     deny?: string[];
   };
 
-  const mergedAllow = Array.from(
-    new Set([...(existingPermissions.allow ?? []), ...(config.settings.permissions.allow ?? [])]),
-  );
-  const mergedDeny = Array.from(
-    new Set([...(existingPermissions.deny ?? []), ...(config.settings.permissions.deny ?? [])]),
-  );
+  const existingMeta = (existing._ohMyHarness ?? {}) as {
+    managedAt?: string;
+    managedPermissions?: { allow?: string[]; deny?: string[] };
+  };
 
-  // Preserve managedAt if content is unchanged
-  const existingMeta = (existing._ohMyHarness ?? {}) as { managedAt?: string };
+  // Previous managed permissions (empty if legacy settings without tracking)
+  const prevManaged = existingMeta.managedPermissions ?? { allow: [], deny: [] };
+  const prevManagedAllow = new Set(prevManaged.allow ?? []);
+  const prevManagedDeny = new Set(prevManaged.deny ?? []);
+
+  // New managed permissions from current config
+  const newManagedAllow = config.settings.permissions.allow ?? [];
+  const newManagedDeny = config.settings.permissions.deny ?? [];
+
+  // User-added = existing - previous managed
+  const userAllow = (existingPermissions.allow ?? []).filter((p) => !prevManagedAllow.has(p));
+  const userDeny = (existingPermissions.deny ?? []).filter((p) => !prevManagedDeny.has(p));
+
+  // Final = user-added + new managed (deduplicated)
+  const mergedAllow = Array.from(new Set([...userAllow, ...newManagedAllow]));
+  const mergedDeny = Array.from(new Set([...userDeny, ...newManagedDeny]));
   const previousManagedAt = existingMeta.managedAt;
 
   const result: Record<string, unknown> = {
@@ -51,6 +63,10 @@ export async function generateSettings(options: GenerateSettingsOptions): Promis
     _ohMyHarness: {
       managedAt: "__PLACEHOLDER__",
       presets: config.presets,
+      managedPermissions: {
+        allow: newManagedAllow,
+        deny: newManagedDeny,
+      },
     },
   };
 

--- a/src/generators/settings.ts
+++ b/src/generators/settings.ts
@@ -9,6 +9,10 @@ export interface GenerateSettingsOptions {
   hooksOutput: HooksOutput;
 }
 
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
 export async function generateSettings(options: GenerateSettingsOptions): Promise<void> {
   const { projectDir, config, hooksOutput } = options;
   const claudeDir = path.join(projectDir, ".claude");
@@ -24,28 +28,35 @@ export async function generateSettings(options: GenerateSettingsOptions): Promis
   }
 
   // Deep merge permissions: preserve user-added, replace managed entries
-  const existingPermissions = (existing.permissions ?? {}) as {
-    allow?: string[];
-    deny?: string[];
-  };
+  const existingPermissions =
+    existing.permissions && typeof existing.permissions === "object" && !Array.isArray(existing.permissions)
+      ? (existing.permissions as Record<string, unknown>)
+      : {};
+  const existingAllow = asStringArray(existingPermissions.allow);
+  const existingDeny = asStringArray(existingPermissions.deny);
 
   const existingMeta = (existing._ohMyHarness ?? {}) as {
     managedAt?: string;
-    managedPermissions?: { allow?: string[]; deny?: string[] };
+    managedPermissions?: { allow?: unknown; deny?: unknown };
   };
 
   // Previous managed permissions (empty if legacy settings without tracking)
-  const prevManaged = existingMeta.managedPermissions ?? { allow: [], deny: [] };
-  const prevManagedAllow = new Set(prevManaged.allow ?? []);
-  const prevManagedDeny = new Set(prevManaged.deny ?? []);
+  const prevManaged =
+    existingMeta.managedPermissions &&
+      typeof existingMeta.managedPermissions === "object" &&
+      !Array.isArray(existingMeta.managedPermissions)
+      ? existingMeta.managedPermissions
+      : {};
+  const prevManagedAllow = new Set(asStringArray(prevManaged.allow));
+  const prevManagedDeny = new Set(asStringArray(prevManaged.deny));
 
   // New managed permissions from current config
-  const newManagedAllow = config.settings.permissions.allow ?? [];
-  const newManagedDeny = config.settings.permissions.deny ?? [];
+  const newManagedAllow = asStringArray(config.settings.permissions.allow);
+  const newManagedDeny = asStringArray(config.settings.permissions.deny);
 
   // User-added = existing - previous managed
-  const userAllow = (existingPermissions.allow ?? []).filter((p) => !prevManagedAllow.has(p));
-  const userDeny = (existingPermissions.deny ?? []).filter((p) => !prevManagedDeny.has(p));
+  const userAllow = existingAllow.filter((p) => !prevManagedAllow.has(p));
+  const userDeny = existingDeny.filter((p) => !prevManagedDeny.has(p));
 
   // Final = user-added + new managed (deduplicated)
   const mergedAllow = Array.from(new Set([...userAllow, ...newManagedAllow]));

--- a/src/generators/settings.ts
+++ b/src/generators/settings.ts
@@ -57,6 +57,12 @@ export async function generateSettings(options: GenerateSettingsOptions): Promis
   // User-added = existing - previous managed
   const userAllow = existingAllow.filter((p) => !prevManagedAllow.has(p));
   const userDeny = existingDeny.filter((p) => !prevManagedDeny.has(p));
+  const userAllowSet = new Set(userAllow);
+  const userDenySet = new Set(userDeny);
+
+  // Only track permissions as managed if they were not already user-owned.
+  const trackedManagedAllow = newManagedAllow.filter((p) => !userAllowSet.has(p));
+  const trackedManagedDeny = newManagedDeny.filter((p) => !userDenySet.has(p));
 
   // Final = user-added + new managed (deduplicated)
   const mergedAllow = Array.from(new Set([...userAllow, ...newManagedAllow]));
@@ -75,8 +81,8 @@ export async function generateSettings(options: GenerateSettingsOptions): Promis
       managedAt: "__PLACEHOLDER__",
       presets: config.presets,
       managedPermissions: {
-        allow: newManagedAllow,
-        deny: newManagedDeny,
+        allow: trackedManagedAllow,
+        deny: trackedManagedDeny,
       },
     },
   };

--- a/tests/unit/settings-generator.test.ts
+++ b/tests/unit/settings-generator.test.ts
@@ -131,6 +131,124 @@ describe("generateSettings", () => {
     expect(settings.permissions.deny).toContain("Bash(rm -rf /)");
   });
 
+  it("removes managed permissions that were removed from harness.yaml", async () => {
+    const hooksOutput = makeHooksOutput();
+
+    // 1st sync: allow has Bash(npm*)
+    const config1 = makeMergedConfig({
+      settings: {
+        permissions: {
+          allow: ["Bash(npm*)"],
+          deny: [],
+        },
+      },
+    });
+    await generateSettings({ projectDir: tmpDir, config: config1, hooksOutput });
+
+    const settingsPath = path.join(tmpDir, ".claude", "settings.json");
+    const after1 = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    expect(after1.permissions.allow).toContain("Bash(npm*)");
+
+    // 2nd sync: allow is now empty (Bash(npm*) removed from harness.yaml)
+    const config2 = makeMergedConfig({
+      settings: {
+        permissions: {
+          allow: [],
+          deny: [],
+        },
+      },
+    });
+    await generateSettings({ projectDir: tmpDir, config: config2, hooksOutput });
+
+    const after2 = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    // Bash(npm*) was managed, so it should be removed
+    expect(after2.permissions.allow).not.toContain("Bash(npm*)");
+  });
+
+  it("preserves user-added permissions when managed permissions change", async () => {
+    const hooksOutput = makeHooksOutput();
+    const claudeDir = path.join(tmpDir, ".claude");
+
+    // 1st sync: managed allow has Bash(npm*)
+    const config1 = makeMergedConfig({
+      settings: {
+        permissions: {
+          allow: ["Bash(npm*)"],
+          deny: ["Bash(rm*)"],
+        },
+      },
+    });
+    await generateSettings({ projectDir: tmpDir, config: config1, hooksOutput });
+
+    // User manually adds their own permission to settings.json
+    const settingsPath = path.join(claudeDir, "settings.json");
+    const settings = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    settings.permissions.allow.push("Bash(git push)");
+    await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2) + "\n");
+
+    // 2nd sync: managed allow changes (removes npm*, adds pnpm*)
+    const config2 = makeMergedConfig({
+      settings: {
+        permissions: {
+          allow: ["Bash(pnpm*)"],
+          deny: [],
+        },
+      },
+    });
+    await generateSettings({ projectDir: tmpDir, config: config2, hooksOutput });
+
+    const after = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    // User-added permission preserved
+    expect(after.permissions.allow).toContain("Bash(git push)");
+    // New managed permission added
+    expect(after.permissions.allow).toContain("Bash(pnpm*)");
+    // Old managed permission removed
+    expect(after.permissions.allow).not.toContain("Bash(npm*)");
+    // Old managed deny removed
+    expect(after.permissions.deny).not.toContain("Bash(rm*)");
+  });
+
+  it("handles missing _ohMyHarness.managedPermissions gracefully (backward compat)", async () => {
+    const hooksOutput = makeHooksOutput();
+    const claudeDir = path.join(tmpDir, ".claude");
+    await fs.mkdir(claudeDir, { recursive: true });
+
+    // Existing settings without managedPermissions (legacy)
+    const legacySettings = {
+      permissions: {
+        allow: ["Bash(npm test)", "Bash(legacy*)"],
+        deny: [],
+      },
+      _ohMyHarness: {
+        managedAt: "2024-01-01T00:00:00.000Z",
+        presets: ["_base"],
+      },
+    };
+    await fs.writeFile(
+      path.join(claudeDir, "settings.json"),
+      JSON.stringify(legacySettings, null, 2) + "\n",
+    );
+
+    // Sync with new config
+    const config = makeMergedConfig({
+      settings: {
+        permissions: {
+          allow: ["Bash(pnpm test*)"],
+          deny: [],
+        },
+      },
+    });
+    await generateSettings({ projectDir: tmpDir, config, hooksOutput });
+
+    const settingsPath = path.join(claudeDir, "settings.json");
+    const after = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    // Legacy permissions preserved (treated as user-added since no managedPermissions existed)
+    expect(after.permissions.allow).toContain("Bash(npm test)");
+    expect(after.permissions.allow).toContain("Bash(legacy*)");
+    // New managed permission added
+    expect(after.permissions.allow).toContain("Bash(pnpm test*)");
+  });
+
   it("is idempotent — running twice with same config produces identical output", async () => {
     const config = makeMergedConfig();
     const hooksOutput = makeHooksOutput();

--- a/tests/unit/settings-generator.test.ts
+++ b/tests/unit/settings-generator.test.ts
@@ -249,6 +249,39 @@ describe("generateSettings", () => {
     expect(after.permissions.allow).toContain("Bash(pnpm test*)");
   });
 
+  it("tolerates malformed existing permission fields without breaking sync", async () => {
+    const hooksOutput = makeHooksOutput();
+    const claudeDir = path.join(tmpDir, ".claude");
+    await fs.mkdir(claudeDir, { recursive: true });
+
+    const malformedSettings = {
+      permissions: {
+        allow: "Bash(npm test)",
+        deny: ["Bash(rm -rf /)", 123, null],
+      },
+      _ohMyHarness: {
+        managedAt: "2024-01-01T00:00:00.000Z",
+        presets: ["_base"],
+        managedPermissions: {
+          allow: "Bash(old*)",
+          deny: ["Bash(rm -rf /)", false],
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(claudeDir, "settings.json"),
+      JSON.stringify(malformedSettings, null, 2) + "\n",
+    );
+
+    await expect(
+      generateSettings({ projectDir: tmpDir, config: makeMergedConfig(), hooksOutput }),
+    ).resolves.not.toThrow();
+
+    const after = JSON.parse(await fs.readFile(path.join(claudeDir, "settings.json"), "utf-8"));
+    expect(after.permissions.allow).toEqual(["Bash(pnpm test*)"]);
+    expect(after.permissions.deny).toEqual(["Bash(rm -rf /)"]);
+  });
+
   it("is idempotent — running twice with same config produces identical output", async () => {
     const config = makeMergedConfig();
     const hooksOutput = makeHooksOutput();

--- a/tests/unit/settings-generator.test.ts
+++ b/tests/unit/settings-generator.test.ts
@@ -282,6 +282,63 @@ describe("generateSettings", () => {
     expect(after.permissions.deny).toEqual(["Bash(rm -rf /)"]);
   });
 
+  it("preserves pre-existing user permissions even when they temporarily overlap with managed ones", async () => {
+    const hooksOutput = makeHooksOutput();
+    const claudeDir = path.join(tmpDir, ".claude");
+    await fs.mkdir(claudeDir, { recursive: true });
+    const settingsPath = path.join(claudeDir, "settings.json");
+
+    const existingSettings = {
+      permissions: {
+        allow: ["Bash(git push)"],
+        deny: [],
+      },
+      _ohMyHarness: {
+        managedAt: "2024-01-01T00:00:00.000Z",
+        presets: ["_base"],
+        managedPermissions: {
+          allow: [],
+          deny: [],
+        },
+      },
+    };
+    await fs.writeFile(settingsPath, JSON.stringify(existingSettings, null, 2) + "\n");
+
+    await generateSettings({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        settings: {
+          permissions: {
+            allow: ["Bash(git push)", "Bash(pnpm test*)"],
+            deny: [],
+          },
+        },
+      }),
+      hooksOutput,
+    });
+
+    const afterFirstSync = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    expect(afterFirstSync.permissions.allow).toContain("Bash(git push)");
+    expect(afterFirstSync._ohMyHarness.managedPermissions.allow).toEqual(["Bash(pnpm test*)"]);
+
+    await generateSettings({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        settings: {
+          permissions: {
+            allow: ["Bash(pnpm test*)"],
+            deny: [],
+          },
+        },
+      }),
+      hooksOutput,
+    });
+
+    const afterSecondSync = JSON.parse(await fs.readFile(settingsPath, "utf-8"));
+    expect(afterSecondSync.permissions.allow).toContain("Bash(git push)");
+    expect(afterSecondSync.permissions.allow).toContain("Bash(pnpm test*)");
+  });
+
   it("is idempotent — running twice with same config produces identical output", async () => {
     const config = makeMergedConfig();
     const hooksOutput = makeHooksOutput();


### PR DESCRIPTION
## Summary
- Fix monotonic permission growth bug in `settings.json` where permissions added via `harness.yaml` could never be removed
- Add `_ohMyHarness.managedPermissions` metadata to track which permissions are managed by oh-my-harness vs user-added
- On sync: user-added permissions are preserved, managed permissions are replaced with current config values
- Backward compatible: legacy settings without `managedPermissions` treat all existing permissions as user-added

## Test plan
- [x] Test: managed permissions removed from harness.yaml are removed from settings.json
- [x] Test: user-added permissions are preserved when managed permissions change
- [x] Test: legacy settings without managedPermissions handled gracefully (backward compat)
- [x] All 9 settings-generator tests pass
- [x] TypeScript type check passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 권한 병합 로직 개선: 비정상 입력을 정규화하고(문자열 배열로), 사용자가 직접 추가한 권한은 보존하며 관리 대상 권한만 추적·갱신하도록 수정
  * 관리된 권한을 설정 파일 메타데이터에 기록(managedPermissions)하고 중복 제거 및 제거된 관리 권한 반영
  * 메타데이터 누락·비정상 형식도 안전하게 처리

* **테스트**
  * 권한 동기화·갱신, 하위 호환성 및 오류 내성 검증 단위 테스트 추가/확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->