### PR TITLE
fix: add retry logic and improve error messages for AI providers

### DIFF
--- a/src/nl/providers/claude-api.ts
+++ b/src/nl/providers/claude-api.ts
@@ -3,6 +3,15 @@ import type { LLMProvider } from "../provider-registry.js";
 const DEFAULT_MODEL = "claude-sonnet-4-20250514";
 const API_URL = "https://api.anthropic.com/v1/messages";
 const REQUEST_TIMEOUT_MS = 60_000;
+const MAX_ATTEMPTS = 3;
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export function createClaudeApiProvider(
   apiKey: string,
@@ -11,43 +20,64 @@ export function createClaudeApiProvider(
   return {
     name: "claude",
     run: async (prompt: string): Promise<string> => {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-      let response: Response;
-      try {
-        response = await fetch(API_URL, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-api-key": apiKey,
-            "anthropic-version": "2023-06-01",
-          },
-          body: JSON.stringify({
-            model,
-            max_tokens: 4096,
-            messages: [{ role: "user", content: prompt }],
-          }),
-          signal: controller.signal,
-        });
-      } finally {
+      let lastError: unknown;
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+        let response: Response;
+        try {
+          response = await fetch(API_URL, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-api-key": apiKey,
+              "anthropic-version": "2023-06-01",
+            },
+            body: JSON.stringify({
+              model,
+              max_tokens: 4096,
+              messages: [{ role: "user", content: prompt }],
+            }),
+            signal: controller.signal,
+          });
+        } catch (err) {
+          clearTimeout(timeout);
+          if ((err as { name?: string }).name === "AbortError") {
+            throw new Error("AI provider request timed out after 60 seconds");
+          }
+          // Network errors are retryable
+          lastError = err;
+          if (attempt < MAX_ATTEMPTS) {
+            await sleep(Math.pow(2, attempt - 1) * 1000);
+          }
+          continue;
+        }
         clearTimeout(timeout);
+
+        if (!response.ok) {
+          if (isRetryableStatus(response.status) && attempt < MAX_ATTEMPTS) {
+            lastError = new Error(`Anthropic API error (${response.status})`);
+            await sleep(Math.pow(2, attempt - 1) * 1000);
+            continue;
+          }
+          const errorBody = await response.text();
+          throw new Error(`Anthropic API error (${response.status}): ${errorBody}`);
+        }
+
+        const data = (await response.json()) as {
+          content: Array<{ type: string; text: string }>;
+        };
+
+        const textBlock = data.content?.find((c) => c.type === "text");
+        if (!textBlock) {
+          throw new Error("Anthropic API returned no text content");
+        }
+
+        return textBlock.text;
       }
 
-      if (!response.ok) {
-        const errorBody = await response.text();
-        throw new Error(`Anthropic API error (${response.status}): ${errorBody}`);
-      }
-
-      const data = (await response.json()) as {
-        content: Array<{ type: string; text: string }>;
-      };
-
-      const textBlock = data.content?.find((c) => c.type === "text");
-      if (!textBlock) {
-        throw new Error("Anthropic API returned no text content");
-      }
-
-      return textBlock.text;
+      throw lastError ?? new Error("Anthropic API request failed after retries");
     },
   };
 }

--- a/src/nl/providers/gemini-api.ts
+++ b/src/nl/providers/gemini-api.ts
@@ -2,9 +2,18 @@ import type { LLMProvider } from "../provider-registry.js";
 
 const DEFAULT_MODEL = "gemini-2.5-flash";
 const REQUEST_TIMEOUT_MS = 60_000;
+const MAX_ATTEMPTS = 3;
 
 function getApiUrl(model: string): string {
   return `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+}
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function createGeminiApiProvider(
@@ -14,43 +23,64 @@ export function createGeminiApiProvider(
   return {
     name: "gemini",
     run: async (prompt: string): Promise<string> => {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-      let response: Response;
-      try {
-        response = await fetch(getApiUrl(model), {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-goog-api-key": apiKey,
-          },
-          body: JSON.stringify({
-            contents: [{ parts: [{ text: prompt }] }],
-            generationConfig: {
-              maxOutputTokens: 4096,
+      let lastError: unknown;
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+        let response: Response;
+        try {
+          response = await fetch(getApiUrl(model), {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-goog-api-key": apiKey,
             },
-          }),
-          signal: controller.signal,
-        });
-      } finally {
+            body: JSON.stringify({
+              contents: [{ parts: [{ text: prompt }] }],
+              generationConfig: {
+                maxOutputTokens: 4096,
+              },
+            }),
+            signal: controller.signal,
+          });
+        } catch (err) {
+          clearTimeout(timeout);
+          if ((err as { name?: string }).name === "AbortError") {
+            throw new Error("AI provider request timed out after 60 seconds");
+          }
+          // Network errors are retryable
+          lastError = err;
+          if (attempt < MAX_ATTEMPTS) {
+            await sleep(Math.pow(2, attempt - 1) * 1000);
+          }
+          continue;
+        }
         clearTimeout(timeout);
+
+        if (!response.ok) {
+          if (isRetryableStatus(response.status) && attempt < MAX_ATTEMPTS) {
+            lastError = new Error(`Gemini API error (${response.status})`);
+            await sleep(Math.pow(2, attempt - 1) * 1000);
+            continue;
+          }
+          const errorBody = await response.text();
+          throw new Error(`Gemini API error (${response.status}): ${errorBody}`);
+        }
+
+        const data = (await response.json()) as {
+          candidates: Array<{ content: { parts: Array<{ text: string }> } }>;
+        };
+
+        const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+        if (!text) {
+          throw new Error("Gemini API returned no content");
+        }
+
+        return text;
       }
 
-      if (!response.ok) {
-        const errorBody = await response.text();
-        throw new Error(`Gemini API error (${response.status}): ${errorBody}`);
-      }
-
-      const data = (await response.json()) as {
-        candidates: Array<{ content: { parts: Array<{ text: string }> } }>;
-      };
-
-      const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
-      if (!text) {
-        throw new Error("Gemini API returned no content");
-      }
-
-      return text;
+      throw lastError ?? new Error("Gemini API request failed after retries");
     },
   };
 }

--- a/src/nl/providers/openai-api.ts
+++ b/src/nl/providers/openai-api.ts
@@ -3,6 +3,15 @@ import type { LLMProvider } from "../provider-registry.js";
 const DEFAULT_MODEL = "gpt-5.4";
 const API_URL = "https://api.openai.com/v1/chat/completions";
 const REQUEST_TIMEOUT_MS = 60_000;
+const MAX_ATTEMPTS = 3;
+
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export function createOpenaiApiProvider(
   apiKey: string,
@@ -11,42 +20,63 @@ export function createOpenaiApiProvider(
   return {
     name: "openai",
     run: async (prompt: string): Promise<string> => {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-      let response: Response;
-      try {
-        response = await fetch(API_URL, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${apiKey}`,
-          },
-          body: JSON.stringify({
-            model,
-            messages: [{ role: "user", content: prompt }],
-            max_completion_tokens: 4096,
-          }),
-          signal: controller.signal,
-        });
-      } finally {
+      let lastError: unknown;
+
+      for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+        let response: Response;
+        try {
+          response = await fetch(API_URL, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Authorization": `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+              model,
+              messages: [{ role: "user", content: prompt }],
+              max_completion_tokens: 4096,
+            }),
+            signal: controller.signal,
+          });
+        } catch (err) {
+          clearTimeout(timeout);
+          if ((err as { name?: string }).name === "AbortError") {
+            throw new Error("AI provider request timed out after 60 seconds");
+          }
+          // Network errors are retryable
+          lastError = err;
+          if (attempt < MAX_ATTEMPTS) {
+            await sleep(Math.pow(2, attempt - 1) * 1000);
+          }
+          continue;
+        }
         clearTimeout(timeout);
+
+        if (!response.ok) {
+          if (isRetryableStatus(response.status) && attempt < MAX_ATTEMPTS) {
+            lastError = new Error(`OpenAI API error (${response.status})`);
+            await sleep(Math.pow(2, attempt - 1) * 1000);
+            continue;
+          }
+          const errorBody = await response.text();
+          throw new Error(`OpenAI API error (${response.status}): ${errorBody}`);
+        }
+
+        const data = (await response.json()) as {
+          choices: Array<{ message: { content: string } }>;
+        };
+
+        const content = data.choices?.[0]?.message?.content;
+        if (!content) {
+          throw new Error("Empty response from OpenAI");
+        }
+
+        return content;
       }
 
-      if (!response.ok) {
-        const errorBody = await response.text();
-        throw new Error(`OpenAI API error (${response.status}): ${errorBody}`);
-      }
-
-      const data = (await response.json()) as {
-        choices: Array<{ message: { content: string } }>;
-      };
-
-      const content = data.choices?.[0]?.message?.content;
-      if (content == null) {
-        throw new Error("OpenAI API returned no content");
-      }
-
-      return content;
+      throw lastError ?? new Error("OpenAI API request failed after retries");
     },
   };
 }

--- a/tests/unit/nl-provider.test.ts
+++ b/tests/unit/nl-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   type LLMProvider,
   type ProviderDefinition,
@@ -7,6 +7,9 @@ import {
   createProvider,
 } from "../../src/nl/provider-registry.js";
 import type { ProviderConfig } from "../../src/nl/config-store.js";
+import { createOpenaiApiProvider } from "../../src/nl/providers/openai-api.js";
+import { createClaudeApiProvider } from "../../src/nl/providers/claude-api.js";
+import { createGeminiApiProvider } from "../../src/nl/providers/gemini-api.js";
 
 describe("provider-registry", () => {
   it("getAvailableProviders returns at least 3 providers", () => {
@@ -131,5 +134,204 @@ describe("provider-registry", () => {
   it("getAvailableModels returns empty array for unknown provider", () => {
     const models = getAvailableModels("unknown-llm");
     expect(models).toEqual([]);
+  });
+});
+
+describe("openai-api provider error handling", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("retries on 429 rate limit and succeeds on second attempt", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response("rate limited", { status: 429 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: "hello" } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const provider = createOpenaiApiProvider("sk-test");
+    const result = await provider.run("test prompt");
+    expect(result).toBe("hello");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on 500 server error and succeeds on second attempt", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(new Response("server error", { status: 500 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            choices: [{ message: { content: "ok" } }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const provider = createOpenaiApiProvider("sk-test");
+    const result = await provider.run("test prompt");
+    expect(result).toBe("ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after 3 failed attempts on 429", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response("rate limited", { status: 429 }));
+
+    const provider = createOpenaiApiProvider("sk-test");
+    await expect(provider.run("test")).rejects.toThrow("429");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on 401 unauthorized", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response("unauthorized", { status: 401 }));
+
+    const provider = createOpenaiApiProvider("sk-test");
+    await expect(provider.run("test")).rejects.toThrow("401");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws timeout error with clear message on AbortError", async () => {
+    vi.stubGlobal("fetch", () => {
+      const err = new DOMException("aborted", "AbortError");
+      return Promise.reject(err);
+    });
+
+    const provider = createOpenaiApiProvider("sk-test");
+    await expect(provider.run("test")).rejects.toThrow(
+      "AI provider request timed out after 60 seconds",
+    );
+  });
+
+  it("throws on empty string response from OpenAI", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          choices: [{ message: { content: "" } }],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const provider = createOpenaiApiProvider("sk-test");
+    await expect(provider.run("test")).rejects.toThrow(
+      "Empty response from OpenAI",
+    );
+  });
+});
+
+describe("claude-api provider error handling", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("retries on 429 rate limit and succeeds on second attempt", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            content: [{ type: "text", text: "hello from claude" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const provider = createClaudeApiProvider("sk-ant-test");
+    const result = await provider.run("test prompt");
+    expect(result).toBe("hello from claude");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after 3 failed attempts on 500", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response("server error", { status: 500 }));
+
+    const provider = createClaudeApiProvider("sk-ant-test");
+    await expect(provider.run("test")).rejects.toThrow("500");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws timeout error with clear message on AbortError", async () => {
+    vi.stubGlobal("fetch", () => {
+      const err = new DOMException("aborted", "AbortError");
+      return Promise.reject(err);
+    });
+
+    const provider = createClaudeApiProvider("sk-ant-test");
+    await expect(provider.run("test")).rejects.toThrow(
+      "AI provider request timed out after 60 seconds",
+    );
+  });
+});
+
+describe("gemini-api provider error handling", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("retries on 429 rate limit and succeeds on second attempt", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(new Response("rate limited", { status: 429 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            candidates: [
+              { content: { parts: [{ text: "hello from gemini" }] } },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const provider = createGeminiApiProvider("gemini-key");
+    const result = await provider.run("test prompt");
+    expect(result).toBe("hello from gemini");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after 3 failed attempts on 429", async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(new Response("rate limited", { status: 429 }));
+
+    const provider = createGeminiApiProvider("gemini-key");
+    await expect(provider.run("test")).rejects.toThrow("429");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws timeout error with clear message on AbortError", async () => {
+    vi.stubGlobal("fetch", () => {
+      const err = new DOMException("aborted", "AbortError");
+      return Promise.reject(err);
+    });
+
+    const provider = createGeminiApiProvider("gemini-key");
+    await expect(provider.run("test")).rejects.toThrow(
+      "AI provider request timed out after 60 seconds",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add exponential backoff retry (max 3 attempts, delays: 1s/2s/4s) for HTTP 429 and 5xx errors in OpenAI, Claude, and Gemini API providers
- Clarify AbortError into a human-readable timeout message: \"AI provider request timed out after 60 seconds\"
- Fix OpenAI empty-string content check: `!content` instead of `content == null` so empty string `\"\"` is rejected

## Test plan
- [x] New tests added before implementation (TDD)
- [x] \"retries on 429 rate limit and succeeds on second attempt\" - openai, claude, gemini
- [x] \"retries on 500 server error and succeeds on second attempt\" - openai
- [x] \"throws after 3 failed attempts\" - openai, claude, gemini
- [x] \"does not retry on 401 unauthorized\" - openai
- [x] \"throws timeout error with clear message on AbortError\" - openai, claude, gemini
- [x] \"throws on empty string response from OpenAI\" - openai
- [x] All 882 tests pass (`npm test`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * AI 모델 제공자(OpenAI, Claude, Gemini)의 안정성 개선
  * 일시적인 API 오류에 대한 자동 재시도 기능 추가
  * 지수 백오프를 통한 지능형 재시도 간격 조절

* **테스트**
  * 재시도 로직 및 오류 처리 검증을 위한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->