### PR TITLE
fix: replace greedy regex with balanced brace parsing in extractJson

### DIFF
--- a/src/nl/parse-intent.ts
+++ b/src/nl/parse-intent.ts
@@ -39,9 +39,20 @@ export const defaultClaudeRunner: LLMRunner = async (prompt) => {
 };
 
 function extractJson(text: string): string {
-  // Try to extract a JSON object from text that may contain extra content
-  const match = text.match(/\{[\s\S]*\}/);
-  if (match) return match[0];
+  // Extract the first complete JSON object using balanced brace counting
+  // to avoid greedy matching that would capture multiple objects
+  const start = text.indexOf("{");
+  if (start === -1) return text.trim();
+
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    if (text[i] === "{") depth++;
+    else if (text[i] === "}") {
+      depth--;
+      if (depth === 0) return text.slice(start, i + 1);
+    }
+  }
+  // If no balanced closing brace found, return the rest of the text
   return text.trim();
 }
 

--- a/src/nl/parse-intent.ts
+++ b/src/nl/parse-intent.ts
@@ -39,21 +39,44 @@ export const defaultClaudeRunner: LLMRunner = async (prompt) => {
 };
 
 function extractJson(text: string): string {
-  // Extract the first complete JSON object using balanced brace counting
-  // to avoid greedy matching that would capture multiple objects
   const start = text.indexOf("{");
   if (start === -1) return text.trim();
 
   let depth = 0;
+  let inString = false;
+  let escaped = false;
+
   for (let i = start; i < text.length; i++) {
-    if (text[i] === "{") depth++;
-    else if (text[i] === "}") {
+    const ch = text[i];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (ch === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (ch === "{") depth++;
+    else if (ch === "}") {
       depth--;
       if (depth === 0) return text.slice(start, i + 1);
     }
   }
-  // If no balanced closing brace found, return the rest of the text
-  return text.trim();
+
+  return text.slice(start).trim();
 }
 
 function validateParsedIntent(obj: unknown): ParsedIntent {

--- a/tests/unit/nl-parse-intent.test.ts
+++ b/tests/unit/nl-parse-intent.test.ts
@@ -108,6 +108,28 @@ describe("parseNaturalLanguage", () => {
     expect(result.presets).toEqual(["react"]);
   });
 
+  it("stops at first complete JSON object, not last closing brace", async () => {
+    const mockRunner: ClaudeRunner = async () =>
+      '{"presets": ["typescript"], "confidence": 0.9, "explanation": "ts project"} extra text {"another": "object"}';
+
+    const result = await parseNaturalLanguage("build typescript", samplePresets, mockRunner);
+    expect(result.presets).toEqual(["typescript"]);
+    expect(result.confidence).toBe(0.9);
+    expect(result.explanation).toBe("ts project");
+  });
+
+  it("extracts first complete JSON with nested braces", async () => {
+    const mockRunner: ClaudeRunner = async () =>
+      'text {"presets": ["react"], "confidence": 0.8, "explanation": "app with val{nested}"} more text {"other":1}';
+
+    const result = await parseNaturalLanguage("build app", samplePresets, mockRunner);
+    expect(result).toBeDefined();
+    expect(result.presets).toEqual(["react"]);
+    expect(result.confidence).toBe(0.8);
+    // Verify it extracted the first complete object (with nested braces in the explanation)
+    expect(result.explanation).toBe("app with val{nested}");
+  });
+
   it("throws when claude CLI runner rejects (not available)", async () => {
     const mockRunner: ClaudeRunner = async () => {
       const err = new Error("spawn claude ENOENT") as NodeJS.ErrnoException;

--- a/tests/unit/nl-parse-intent.test.ts
+++ b/tests/unit/nl-parse-intent.test.ts
@@ -130,6 +130,35 @@ describe("parseNaturalLanguage", () => {
     expect(result.explanation).toBe("app with val{nested}");
   });
 
+  it("ignores closing braces that appear inside quoted strings", async () => {
+    const mockRunner: ClaudeRunner = async () =>
+      'prefix {"presets": ["react"], "confidence": 0.8, "explanation": "brace } in string"} trailing';
+
+    const result = await parseNaturalLanguage("build app", samplePresets, mockRunner);
+
+    expect(result.presets).toEqual(["react"]);
+    expect(result.explanation).toBe("brace } in string");
+  });
+
+  it("handles escaped quotes and braces inside quoted strings", async () => {
+    const mockRunner: ClaudeRunner = async () =>
+      'prefix {"presets": ["react"], "confidence": 0.8, "explanation": "quote \\"{test}\\" kept"} trailing';
+
+    const result = await parseNaturalLanguage("build app", samplePresets, mockRunner);
+
+    expect(result.presets).toEqual(["react"]);
+    expect(result.explanation).toBe('quote "{test}" kept');
+  });
+
+  it("still rejects malformed JSON after dropping prefix text", async () => {
+    const mockRunner: ClaudeRunner = async () =>
+      'prefix {"presets": ["react"], "confidence": 0.8, "explanation": "missing end"';
+
+    await expect(parseNaturalLanguage("build app", samplePresets, mockRunner)).rejects.toThrow(
+      "Failed to parse JSON from claude output",
+    );
+  });
+
   it("throws when claude CLI runner rejects (not available)", async () => {
     const mockRunner: ClaudeRunner = async () => {
       const err = new Error("spawn claude ENOENT") as NodeJS.ErrnoException;


### PR DESCRIPTION
## Summary
- Replaced greedy regex pattern `/\{[\s\S]*\}/` with balanced brace counter
- Fixes incorrect JSON parsing when text contains multiple objects or nested structures
- Added two test cases for edge cases

## Test plan
- [x] Unit tests for parseNaturalLanguage with multiple JSON objects
- [x] Unit tests for parseNaturalLanguage with nested braces in JSON values
- [x] All 33 nl-parse-intent tests pass
- [x] No TypeScript errors
- [x] Build succeeds

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 자연어 입력에서 JSON 추출 파싱 알고리즘을 개선하여 복잡한 중첩 구조와 여러 JSON 객체가 포함된 경우를 더 안정적으로 처리하도록 변경

## 테스트
* JSON 추출 파싱의 정확성을 검증하기 위한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->