### PR TITLE
fix: remove stale managed sections from CLAUDE.md on sync

### DIFF
--- a/src/generators/claude-md.ts
+++ b/src/generators/claude-md.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
-import { upsertManagedSection } from "../utils/markdown.js";
+import { extractManagedSections, removeManagedSection, upsertManagedSection } from "../utils/markdown.js";
 
 export interface GenerateClaudeMdOptions {
   projectDir: string;
@@ -22,6 +22,15 @@ export async function generateClaudeMd(options: GenerateClaudeMdOptions): Promis
       content = "";
     } else {
       throw error;
+    }
+  }
+
+  // Remove managed sections that are no longer in the current config
+  const currentIds = new Set(config.claudeMdSections.map((s) => s.id));
+  const existingIds = extractManagedSections(content).map((s) => s.id);
+  for (const id of existingIds) {
+    if (!currentIds.has(id)) {
+      content = removeManagedSection(content, id);
     }
   }
 

--- a/tests/integration/claude-md-management.test.ts
+++ b/tests/integration/claude-md-management.test.ts
@@ -84,8 +84,10 @@ describe("generateClaudeMd()", () => {
 
     content = await readFile(claudeMdPath, "utf-8");
     expect(content).toContain("Updated content one");
-    // section-two marker is removed because it is no longer in the config
+    // section-two marker pair is removed because it is no longer in the config
     expect(hasManagedSection(content, "section-two")).toBe(false);
+    expect(content).not.toContain("<!-- oh-my-harness:start:section-two -->");
+    expect(content).not.toContain("<!-- oh-my-harness:end:section-two -->");
   });
 
   it("manages multiple sections simultaneously in correct priority order", async () => {

--- a/tests/integration/claude-md-management.test.ts
+++ b/tests/integration/claude-md-management.test.ts
@@ -74,9 +74,9 @@ describe("generateClaudeMd()", () => {
     expect(hasManagedSection(content, "section-one")).toBe(true);
     expect(hasManagedSection(content, "section-two")).toBe(true);
 
-    // Now regenerate with only one section — section-two should remain in file
-    // (generateClaudeMd only upserts, does not remove absent sections)
-    // But section-one content can be updated independently
+    // Now regenerate with only one section — section-two should be removed
+    // (generateClaudeMd removes managed sections absent from config)
+    // section-one content is updated independently
     const configWithOne = makeConfig([
       { id: "section-one", title: "Section One", content: "Updated content one", priority: 10 },
     ]);
@@ -84,8 +84,8 @@ describe("generateClaudeMd()", () => {
 
     content = await readFile(claudeMdPath, "utf-8");
     expect(content).toContain("Updated content one");
-    // section-two marker still present (upsert doesn't remove)
-    expect(hasManagedSection(content, "section-two")).toBe(true);
+    // section-two marker is removed because it is no longer in the config
+    expect(hasManagedSection(content, "section-two")).toBe(false);
   });
 
   it("manages multiple sections simultaneously in correct priority order", async () => {

--- a/tests/unit/claude-md-generator.test.ts
+++ b/tests/unit/claude-md-generator.test.ts
@@ -105,6 +105,29 @@ More user content.
     void first; // used only to trigger first write
   });
 
+  it("removes managed sections that are no longer in config after sync", async () => {
+    // First sync: config has rule-a
+    const configWithA = makeMergedConfig({
+      claudeMdSections: [
+        { id: "rule-a", title: "Rule A", content: "## Rule A\n- item a", priority: 10 },
+      ],
+    });
+    await generateClaudeMd({ projectDir: tmpDir, config: configWithA });
+
+    // Second sync: config no longer has rule-a
+    const configWithoutA = makeMergedConfig({
+      claudeMdSections: [],
+    });
+    const result = await generateClaudeMd({ projectDir: tmpDir, config: configWithoutA });
+
+    expect(result).not.toContain("<!-- oh-my-harness:start:rule-a -->");
+    expect(result).not.toContain("<!-- oh-my-harness:end:rule-a -->");
+    expect(result).not.toContain("item a");
+
+    const written = await fs.readFile(path.join(tmpDir, "CLAUDE.md"), "utf8");
+    expect(written).toBe(result);
+  });
+
   it("handles empty config (no sections)", async () => {
     const config = makeMergedConfig();
 


### PR DESCRIPTION
## Summary
- `generateClaudeMd` now removes managed sections that are no longer present in the current config before upserting the active ones
- Fixes the bug where deleting a rule from `harness.yaml` left its `<!-- oh-my-harness:start/end:id -->` block permanently in `CLAUDE.md`
- Uses the already-existing `extractManagedSections` and `removeManagedSection` utilities from `src/utils/markdown.ts`

## Test plan
- [x] New unit test: "removes managed sections that are no longer in config after sync" — first sync adds `rule-a`, second sync with empty config asserts `rule-a` section is gone
- [x] Updated integration test in `tests/integration/claude-md-management.test.ts` to reflect correct behavior (stale section is removed, not preserved)
- [x] All 88 test files / 873 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 설정에서 제거된 관리 섹션이 이제 자동으로 정리되고 제거됩니다.

* **개선**
  * 더 이상 필요하지 않은 관리 섹션의 자동 제거 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->