### PR TITLE
fix: normalize paths in path-guard to prevent traversal bypass

### DIFF
--- a/src/catalog/blocks/path-guard.ts
+++ b/src/catalog/blocks/path-guard.ts
@@ -23,26 +23,41 @@ INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 [[ -z "$FILE_PATH" ]] && exit 0
 # Normalize path to prevent directory traversal attacks (e.g., ./foo/../dist/secret.js -> dist/secret.js)
-NORMALIZED=$(python3 -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
+if command -v python3 >/dev/null 2>&1; then
+  if ! NORMALIZED=$(python3 -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null); then
+    _log_event "block" "oh-my-harness: path normalization unavailable for non-canonical path"
+    echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: path normalization unavailable for non-canonical path\\\"}"
+    exit 0
+  fi
+else
+  case "$FILE_PATH" in
+    /*|../*|*/../*|*/..|./*|*/./*|*/.)
+      _log_event "block" "oh-my-harness: path normalization unavailable for non-canonical path"
+      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: path normalization unavailable for non-canonical path\\\"}"
+      exit 0
+      ;;
+  esac
+  NORMALIZED="$FILE_PATH"
+fi
 BLOCKED_PATHS=({{#each blockedPaths}}"{{{this}}}" {{/each}})
 for BLOCKED in "\${BLOCKED_PATHS[@]}"; do
   if [[ "$BLOCKED" == */ ]]; then
     if [[ "$NORMALIZED" == "$BLOCKED"* || "$NORMALIZED" == *"/$BLOCKED"* ]]; then
       _log_event "block" "oh-my-harness: file path matches blocked directory: $BLOCKED"
-      echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file path matches blocked directory: $BLOCKED\\"}"
+      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: file path matches blocked directory: $BLOCKED\\\"}"
       exit 0
     fi
   elif [[ "$BLOCKED" == \\** ]]; then
     PATTERN="\${BLOCKED#\\*}"
     if [[ "$NORMALIZED" == *"$PATTERN" ]]; then
       _log_event "block" "oh-my-harness: file path matches blocked pattern: $BLOCKED"
-      echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file path matches blocked pattern: $BLOCKED\\"}"
+      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: file path matches blocked pattern: $BLOCKED\\\"}"
       exit 0
     fi
   else
     if [[ "$NORMALIZED" == "$BLOCKED" || "$NORMALIZED" == *"/$BLOCKED" ]]; then
       _log_event "block" "oh-my-harness: file path matches blocked path: $BLOCKED"
-      echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file path matches blocked path: $BLOCKED\\"}"
+      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: file path matches blocked path: $BLOCKED\\\"}"
       exit 0
     fi
   fi

--- a/src/catalog/blocks/path-guard.ts
+++ b/src/catalog/blocks/path-guard.ts
@@ -22,23 +22,25 @@ set -euo pipefail
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
 [[ -z "$FILE_PATH" ]] && exit 0
+# Normalize path to prevent directory traversal attacks (e.g., ./foo/../dist/secret.js -> dist/secret.js)
+NORMALIZED=$(python3 -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")
 BLOCKED_PATHS=({{#each blockedPaths}}"{{{this}}}" {{/each}})
 for BLOCKED in "\${BLOCKED_PATHS[@]}"; do
   if [[ "$BLOCKED" == */ ]]; then
-    if [[ "$FILE_PATH" == "$BLOCKED"* || "$FILE_PATH" == *"/$BLOCKED"* ]]; then
+    if [[ "$NORMALIZED" == "$BLOCKED"* || "$NORMALIZED" == *"/$BLOCKED"* ]]; then
       _log_event "block" "oh-my-harness: file path matches blocked directory: $BLOCKED"
       echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file path matches blocked directory: $BLOCKED\\"}"
       exit 0
     fi
   elif [[ "$BLOCKED" == \\** ]]; then
     PATTERN="\${BLOCKED#\\*}"
-    if [[ "$FILE_PATH" == *"$PATTERN" ]]; then
+    if [[ "$NORMALIZED" == *"$PATTERN" ]]; then
       _log_event "block" "oh-my-harness: file path matches blocked pattern: $BLOCKED"
       echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file path matches blocked pattern: $BLOCKED\\"}"
       exit 0
     fi
   else
-    if [[ "$FILE_PATH" == "$BLOCKED" || "$FILE_PATH" == *"/$BLOCKED" ]]; then
+    if [[ "$NORMALIZED" == "$BLOCKED" || "$NORMALIZED" == *"/$BLOCKED" ]]; then
       _log_event "block" "oh-my-harness: file path matches blocked path: $BLOCKED"
       echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file path matches blocked path: $BLOCKED\\"}"
       exit 0

--- a/tests/integration/catalog-block-execution.test.ts
+++ b/tests/integration/catalog-block-execution.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, mkdir, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
@@ -29,17 +29,27 @@ function hasJq(): boolean {
   }
 }
 
-function runScript(scriptPath: string, stdin: string): string {
+function runScript(scriptPath: string, stdin: string, env?: NodeJS.ProcessEnv): string {
   try {
-    return execSync(`bash "${scriptPath}"`, {
+    return execSync(`/bin/bash "${scriptPath}"`, {
       input: stdin,
       cwd: tmpDir,
       encoding: "utf-8",
       timeout: 5000,
+      env: env ?? process.env,
     });
   } catch (e) {
     return (e as { stdout?: string }).stdout ?? "";
   }
+}
+
+async function makeBrokenPythonPath(): Promise<string> {
+  const binDir = join(tmpDir, "bin-no-python");
+  await mkdir(binDir, { recursive: true });
+  const pythonPath = join(binDir, "python3");
+  await writeFile(pythonPath, "#!/bin/bash\nexit 127\n", { mode: 0o755 });
+  await chmod(pythonPath, 0o755);
+  return `${binDir}:${process.env.PATH ?? ""}`;
 }
 
 describe("catalog block execution", () => {
@@ -84,14 +94,11 @@ describe("catalog block execution", () => {
       JSON.stringify({ tool_name: "Bash", tool_input: { command: "npm test" } }),
     );
 
-    // No block JSON in output
     const trimmed = stdout.trim();
     if (trimmed.length > 0) {
-      // If there is output it must NOT be a block decision
       const result = JSON.parse(trimmed);
       expect(result.decision).not.toBe("block");
     } else {
-      // Empty output means the script exited cleanly without blocking
       expect(trimmed).toBe("");
     }
   });
@@ -179,7 +186,6 @@ describe("catalog block execution", () => {
     const scriptPath = join(tmpDir, "path-guard-normalize.sh");
     await writeFile(scriptPath, wrapped, { mode: 0o755 });
 
-    // Test path traversal bypass: ./foo/../dist/secret.js should be normalized to dist/secret.js
     const stdout = runScript(
       scriptPath,
       JSON.stringify({
@@ -191,5 +197,32 @@ describe("catalog block execution", () => {
     const result = JSON.parse(stdout.trim());
     expect(result.decision).toBe("block");
     expect(result.reason).toContain("dist/");
+  });
+
+  it("path-guard: blocks non-canonical paths when python3 normalization fails", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+
+    const rendered = renderTemplate(pathGuard.template, {
+      blockedPaths: ["src/generated/"],
+    });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "path-guard-no-python.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({
+        tool_name: "Write",
+        tool_input: { file_path: "src/foo/../generated/file.ts" },
+      }),
+      { ...process.env, PATH: await makeBrokenPythonPath() },
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("path normalization unavailable");
   });
 });

--- a/tests/integration/catalog-block-execution.test.ts
+++ b/tests/integration/catalog-block-execution.test.ts
@@ -165,4 +165,31 @@ describe("catalog block execution", () => {
       expect(trimmed).toBe("");
     }
   });
+
+  it("path-guard: generated script normalizes path before comparison to prevent traversal bypass", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+
+    const rendered = renderTemplate(pathGuard.template, {
+      blockedPaths: ["dist/"],
+    });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "path-guard-normalize.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    // Test path traversal bypass: ./foo/../dist/secret.js should be normalized to dist/secret.js
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({
+        tool_name: "Write",
+        tool_input: { file_path: "./foo/../dist/secret.js" },
+      }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("dist/");
+  });
 });


### PR DESCRIPTION
## Summary
- Add explicit path normalization in path-guard bash script using python3
- Prevents directory traversal attacks (e.g., `./foo/../dist/secret.js` -> `dist/secret.js`)
- Normalizes paths before all path comparisons (directory prefixes, exact files, wildcard patterns)
- Gracefully falls back to original path if python3 unavailable

## Test plan
- [x] New test: `path-guard: generated script normalizes path before comparison to prevent traversal bypass`
- [x] All existing path-guard tests still pass (6 existing + 1 new = 7 total)
- [x] Full test suite passes (catalog-block-execution)
- [x] Build succeeds with no TypeScript errors

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 파일 경로 비교에 정규화 추가 및 정규화 실패(또는 python3 부재) 시 즉시 차단 처리로 경로 검증 안정성 향상
  * 쉘 패턴 기반의 비정규/경로 횡단 패턴 감지 추가 및 차단 로직에 정규화된 경로 사용, 차단 출력의 JSON 이스케이프 형식 보강

* **테스트**
  * 정규화 가능/불가 상황을 포함한 통합 테스트 추가(정규화 도구 부재 시 동작 시뮬레이션 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->