### PR TITLE
chore: bump version to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.8.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.8.1",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package version from 0.9.0 to 0.10.0
- sync package-lock root version metadata
- prepare release branch after post-v0.9.0 feature and fix merges

## Why minor
- includes a user-facing feature since v0.9.0 (`feat/github-star-prompt`)
- also includes multiple reliability and security fixes

## Verification
- npm test
- npm run lint