### PR TITLE
fix: use absolute paths in hook commands to survive cwd changes

### DIFF
--- a/src/cli/command-checker.ts
+++ b/src/cli/command-checker.ts
@@ -79,7 +79,7 @@ export async function checkHarnessCommands(
   const path = await import("node:path");
 
   for (const hook of hooks) {
-    const scriptPath = hook.command.replace(/^bash\s+/, "");
+    const scriptPath = hook.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "");
     const fullPath = path.join(projectDir, scriptPath);
 
     let content: string;

--- a/src/cli/harness-tester.ts
+++ b/src/cli/harness-tester.ts
@@ -179,11 +179,11 @@ export function generateBlockTestCases(
     };
     const aliases = blockIdAliases[block.id] ?? [block.id];
     const matchedHook = registeredHooks?.find((h) => {
-      const scriptName = h.command.replace(/^bash\s+/, "");
+      const scriptName = h.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "");
       return aliases.some((alias) => scriptName.includes(alias));
     });
     const hookScript = matchedHook
-      ? matchedHook.command.replace(/^bash\s+/, "")
+      ? matchedHook.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "")
       : `.claude/hooks/catalog-${block.id}.sh`;
 
     switch (block.id) {

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -2,9 +2,12 @@ import { mkdir, writeFile, chmod, readFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
 
-function buildLoggerSnippet(event: string): string {
+function buildLoggerSnippet(event: string, projectDir?: string): string {
+  const stateDir = projectDir
+    ? `${projectDir}/.claude/hooks/.state`
+    : ".claude/hooks/.state";
   return `# --- oh-my-harness event logger ---
-_OMH_STATE_DIR=".claude/hooks/.state"
+_OMH_STATE_DIR="${stateDir}"
 mkdir -p "$_OMH_STATE_DIR" 2>/dev/null || true
 _OMH_HOOK_NAME="$(basename "$0")"
 _OMH_EVENT="${event}"
@@ -20,8 +23,8 @@ trap '[ "$_OMH_LOGGED" -eq 0 ] && _log_event "allow"' EXIT
 # --- end logger ---`;
 }
 
-export function wrapWithLogger(script: string, event: string = "unknown"): string {
-  const snippet = buildLoggerSnippet(event);
+export function wrapWithLogger(script: string, event: string = "unknown", projectDir?: string): string {
+  const snippet = buildLoggerSnippet(event, projectDir);
   if (script.includes("INPUT=$(cat)")) {
     return script.replace("INPUT=$(cat)", `INPUT=$(cat)\n\n${snippet}`);
   }
@@ -145,14 +148,14 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
     usedScriptNames.add(scriptName);
 
     const scriptPath = join(hooksDir, scriptName);
-    const wrappedScript = wrapWithLogger(hook.inline, hook.event);
+    const wrappedScript = wrapWithLogger(hook.inline, hook.event, projectDir);
     await writeFile(scriptPath, wrappedScript, "utf8");
     await chmod(scriptPath, 0o755);
     generatedFiles.push(scriptPath);
 
     const entry = {
       matcher: hook.matcher,
-      hooks: [{ type: "command" as const, command: `bash .claude/hooks/${scriptName}` }],
+      hooks: [{ type: "command" as const, command: `bash "${scriptPath}"` }],
     };
     if (!hooksConfig[hook.event]) {
       hooksConfig[hook.event] = [];

--- a/tests/integration/multi-block-execution.test.ts
+++ b/tests/integration/multi-block-execution.test.ts
@@ -416,7 +416,7 @@ describe("hooksConfig structure validation", () => {
         // Each hook has type: "command" and command string
         expect(hook.type).toBe("command");
         expect(typeof hook.command).toBe("string");
-        expect(hook.command).toMatch(/\.sh$/);
+        expect(hook.command).toMatch(/\.sh"?$/);
       }
     }
   });

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, readFile, stat } from "node:fs/promises";
+import { mkdtemp, rm, readFile, stat, access } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { generateHooks, wrapWithLogger } from "../../src/generators/hooks.js";
 import type { MergedConfig } from "../../src/core/preset-types.js";
+
+const execFileAsync = promisify(execFile);
 
 function makeMergedConfig(overrides: Partial<MergedConfig> = {}): MergedConfig {
   return {
@@ -586,5 +590,81 @@ describe("generateHooks — extended events", () => {
     expect(result.generatedFiles).toHaveLength(2);
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(1);
     expect(result.hooksConfig["SessionStart"]).toHaveLength(1);
+  });
+});
+
+describe("generateHooks — cwd-independence", () => {
+  let projectDir: string;
+  let differentDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "oh-my-harness-cwd-"));
+    differentDir = await mkdtemp(join(tmpdir(), "oh-my-harness-other-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(differentDir, { recursive: true, force: true });
+  });
+
+  it("hook script executes successfully when cwd differs from projectDir", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          { id: "cwd-test", matcher: "Bash", inline: '#!/bin/bash\nset -euo pipefail\nINPUT=$(cat)\nexit 0' },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+
+    // Execute the hook script from a DIFFERENT working directory, piping empty stdin
+    const { stderr } = await execFileAsync("bash", ["-c", `echo '{}' | bash "${scriptPath}"`], {
+      cwd: differentDir,
+      env: { ...process.env },
+      timeout: 5000,
+    });
+
+    // Script should exit 0 (no error thrown)
+    expect(stderr).toBe("");
+  });
+
+  it("logger writes events.jsonl to absolute path under projectDir, not cwd", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          {
+            id: "logger-test",
+            matcher: "Bash",
+            inline: '#!/bin/bash\nset -euo pipefail\nINPUT=$(cat)\n_log_event "block" "test"\nexit 0',
+          },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+
+    // Execute from a different directory, piping empty stdin
+    await execFileAsync("bash", ["-c", `echo '{}' | bash "${scriptPath}"`], {
+      cwd: differentDir,
+      env: { ...process.env },
+      timeout: 5000,
+    });
+
+    // events.jsonl should be under projectDir, NOT under differentDir
+    const eventsPath = join(projectDir, ".claude/hooks/.state/events.jsonl");
+    await expect(access(eventsPath)).resolves.toBeUndefined();
+
+    const events = await readFile(eventsPath, "utf8");
+    expect(events).toContain('"decision":"block"');
+    expect(events).toContain('"reason":"test"');
+
+    // Verify nothing was written under differentDir
+    const wrongEventsPath = join(differentDir, ".claude/hooks/.state/events.jsonl");
+    await expect(access(wrongEventsPath)).rejects.toThrow();
   });
 });

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -95,10 +95,10 @@ describe("generateHooks", () => {
     expect(result.hooksConfig).toHaveProperty("PostToolUse");
 
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: "bash .claude/hooks/command-guard.sh" }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/command-guard.sh")}"` }] },
     ]);
     expect(result.hooksConfig["PostToolUse"]).toEqual([
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash .claude/hooks/lint-on-save.sh" }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/lint-on-save.sh")}"` }] },
     ]);
   });
 
@@ -168,8 +168,8 @@ describe("generateHooks", () => {
 
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: "bash .claude/hooks/guard-bash.sh" }] },
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash .claude/hooks/guard-edit.sh" }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/guard-bash.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/guard-edit.sh")}"` }] },
     ]);
   });
 
@@ -190,7 +190,7 @@ describe("generateHooks", () => {
     const scriptPath = join(projectDir, `.claude/hooks/${safeId}.sh`);
     expect(result.generatedFiles).toContain(scriptPath);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash .claude/hooks/${safeId}.sh` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, `.claude/hooks/${safeId}.sh`)}"` }] },
     ]);
     // Ensure no file was written outside the hooks dir
     const content = await readFile(scriptPath, "utf8");
@@ -217,8 +217,8 @@ describe("generateHooks", () => {
     expect(result.generatedFiles).toContain(file1);
     expect(result.generatedFiles).toContain(file2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: "bash .claude/hooks/hook.sh" }] },
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash .claude/hooks/hook-1.sh" }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/hook.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/hook-1.sh")}"` }] },
     ]);
   });
 
@@ -314,8 +314,9 @@ describe("generateHooks", () => {
     // Check hooksConfig contains both hooks
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
     const commands = result.hooksConfig["PreToolUse"].map(h => h.hooks[0].command);
-    expect(commands).toContain("bash .claude/hooks/myhook.sh");
-    expect(commands).toContain("bash .claude/hooks/myhook-1.sh");
+    expect(commands).toContain(`bash "${join(projectDir, ".claude/hooks/myhook.sh")}"`);
+    expect(commands).toContain(`bash "${join(projectDir, ".claude/hooks/myhook-1.sh")}"`);
+
   });
 
   it("avoids file collision when same hook id exists in different events", async () => {
@@ -338,10 +339,10 @@ describe("generateHooks", () => {
     expect(result.generatedFiles).toContain(file1);
     expect(result.generatedFiles).toContain(file2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: "bash .claude/hooks/myhook.sh" }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/myhook.sh")}"` }] },
     ]);
     expect(result.hooksConfig["PostToolUse"]).toEqual([
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash .claude/hooks/myhook-1.sh" }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/myhook-1.sh")}"` }] },
     ]);
   });
 });
@@ -404,6 +405,18 @@ describe("wrapWithLogger", () => {
     const result = wrapWithLogger(script);
     expect(result).toContain("_OMH_STATE_DIR");
     expect(result).toContain("#!/usr/bin/env bash");
+  });
+
+  it("produces absolute _OMH_STATE_DIR when projectDir is provided", () => {
+    const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
+    const result = wrapWithLogger(script, "PreToolUse", "/tmp/my-project");
+    expect(result).toContain('_OMH_STATE_DIR="/tmp/my-project/.claude/hooks/.state"');
+  });
+
+  it("keeps relative _OMH_STATE_DIR when projectDir is omitted", () => {
+    const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
+    const result = wrapWithLogger(script, "PreToolUse");
+    expect(result).toContain('_OMH_STATE_DIR=".claude/hooks/.state"');
   });
 });
 


### PR DESCRIPTION
## Summary
- Hook commands in `settings.json` used relative paths (`bash .claude/hooks/foo.sh`) which broke when Claude Code's cwd changed during a session (e.g., `cd connector/ && npm run build`)
- Now generates absolute paths using `projectDir` with shell quoting for space safety (`bash "/abs/path/.claude/hooks/foo.sh"`)
- Logger snippet's `_OMH_STATE_DIR` also converted to absolute path via optional `projectDir` parameter
- Updated `harness-tester.ts` and `command-checker.ts` to strip quotes when parsing command strings

## Changes
| File | What |
|------|------|
| `src/generators/hooks.ts` | `buildLoggerSnippet`/`wrapWithLogger` accept optional `projectDir`; command uses absolute `scriptPath` |
| `src/cli/harness-tester.ts` | Strip surrounding quotes from command parsing (lines 182, 186) |
| `src/cli/command-checker.ts` | Strip surrounding quotes from command parsing (line 82) |
| `tests/unit/hooks-generator.test.ts` | Updated assertions to expect absolute paths; added `projectDir` wrapWithLogger tests |
| `tests/integration/multi-block-execution.test.ts` | Updated regex to handle quoted paths |

Closes #59

## Test plan
- [x] All 918 tests pass (89 test files)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [x] Unit tests verify absolute paths in generated hook commands
- [x] Unit tests verify `wrapWithLogger` with/without `projectDir`
- [x] Existing `wrapWithLogger` call sites (33+) unaffected (param is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 큰따옴표로 묶인 스크립트 경로 처리 개선(예: "script.sh")으로 훅 감지 정확도 향상
  * 훅 명령어 파싱 오류로 인한 누락 사례 수정

* **개선사항**
  * 훅 실행에 절대 경로 및 인용(quoted paths) 사용으로 더 안정적인 실행 보장
  * 로거 상태 디렉터리가 프로젝트별로 분리되어 여러 프로젝트 동시 관리 개선

* **테스트**
  * 다양한 작업 디렉터리에서 훅 실행 및 상태 기록 동작을 검증하는 통합/단위 테스트 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->