### PR TITLE
chore: bump version to 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Patch version bump `0.10.0` → `0.10.1` for hook path stability fix
- Aligns `package.json` and `package-lock.json` root versions

## Dependencies
- Merge #60 first (fix: use absolute paths in hook commands to survive cwd changes)

## Test plan
- [x] `npm install --package-lock-only` to sync lock file
- [x] Merge #60 before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 버전 0.10.1로 업데이트됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->