### PR TITLE
fix: replace flock with tmp+mv for macOS compatibility in tdd-guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ CLAUDE.md
 # oh-my-harness
 .claude/hooks/
 .claude/hooks/.state/
+.omx/

--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -46,17 +46,14 @@ SRC_RE='{{{srcPattern}}}'
 TEST_RE="\${TEST_RE//\\\\\\\\/\\\\}"
 SRC_RE="\${SRC_RE//\\\\\\\\/\\\\}"
 if [[ "\$FILE_PATH" =~ \$TEST_RE ]]; then
-  # 테스트 파일 수정 → 기록 + 통과 (flock으로 원자적 읽기/쓰기)
-  (
-    flock -x 200
-    if [[ ! -f "\$HISTORY_FILE" ]]; then
-      echo '{"edits":[]}' > "\$HISTORY_FILE"
-    fi
-    UPDATED=$(jq --arg f "\$FILE_PATH" '.edits += [$f] | .edits |= unique' "\$HISTORY_FILE" 2>/dev/null) || true
-    if [[ -n "\$UPDATED" ]]; then
-      echo "\$UPDATED" > "\$HISTORY_FILE"
-    fi
-  ) 200>"\$HISTORY_FILE.lock"
+  # 테스트 파일 수정 → 기록 + 통과 (tmp+mv로 원자적 쓰기, 크로스 플랫폼)
+  if [[ ! -f "\$HISTORY_FILE" ]]; then
+    echo '{"edits":[]}' > "\$HISTORY_FILE"
+  fi
+  UPDATED=$(jq --arg f "\$FILE_PATH" '.edits += [$f] | .edits |= unique' "\$HISTORY_FILE" 2>/dev/null) || true
+  if [[ -n "\$UPDATED" ]]; then
+    echo "\$UPDATED" > "\$HISTORY_FILE.tmp" && mv "\$HISTORY_FILE.tmp" "\$HISTORY_FILE"
+  fi
   exit 0
 fi
 
@@ -75,25 +72,20 @@ if [[ ! -f "\$HISTORY_FILE" ]]; then
   exit 0
 fi
 
-# edit-history에서 테스트 파일 검색 (flock으로 원자적 읽기/쓰기)
-DECISION=$(
-  (
-    flock -x 200
-    if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
-      # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
-      UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
-        .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_"))) | not)]
-        | .edits += [$f] | .edits |= unique
-      ' "\$HISTORY_FILE" 2>/dev/null) || true
-      if [[ -n "\$UPDATED" ]]; then
-        echo "\$UPDATED" > "\$HISTORY_FILE"
-      fi
-      echo "allow"
-    else
-      echo "block"
-    fi
-  ) 200>"\$HISTORY_FILE.lock"
-)
+# edit-history에서 테스트 파일 검색 (tmp+mv로 원자적 쓰기, 크로스 플랫폼)
+if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
+  # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
+  UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
+    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_"))) | not)]
+    | .edits += [$f] | .edits |= unique
+  ' "\$HISTORY_FILE" 2>/dev/null) || true
+  if [[ -n "\$UPDATED" ]]; then
+    echo "\$UPDATED" > "\$HISTORY_FILE.tmp" && mv "\$HISTORY_FILE.tmp" "\$HISTORY_FILE"
+  fi
+  DECISION="allow"
+else
+  DECISION="block"
+fi
 
 if [[ "\$DECISION" == "allow" ]]; then
   exit 0

--- a/src/cli/event-logger.ts
+++ b/src/cli/event-logger.ts
@@ -5,7 +5,7 @@ export interface HookEvent {
   ts: string;
   event: string;
   hook: string;
-  decision: "block" | "allow";
+  decision: "block" | "allow" | "error";
   reason?: string;
   tool?: string;
 }
@@ -42,7 +42,7 @@ export async function readEvents(projectDir: string): Promise<HookEvent[]> {
         typeof parsed.ts === "string" &&
         typeof parsed.event === "string" &&
         typeof parsed.hook === "string" &&
-        (parsed.decision === "block" || parsed.decision === "allow")
+        (parsed.decision === "block" || parsed.decision === "allow" || parsed.decision === "error")
       ) {
         events.push(parsed as unknown as HookEvent);
       }
@@ -66,7 +66,8 @@ export interface EventStats {
   totalEvents: number;
   blockCount: number;
   allowCount: number;
-  byHook: Record<string, { block: number; allow: number }>;
+  errorCount: number;
+  byHook: Record<string, { block: number; allow: number; error: number }>;
 }
 
 export function aggregateStats(events: HookEvent[]): EventStats {
@@ -74,15 +75,17 @@ export function aggregateStats(events: HookEvent[]): EventStats {
     totalEvents: events.length,
     blockCount: 0,
     allowCount: 0,
+    errorCount: 0,
     byHook: {},
   };
 
   for (const e of events) {
     if (e.decision === "block") stats.blockCount++;
+    else if (e.decision === "error") stats.errorCount++;
     else stats.allowCount++;
 
     if (!stats.byHook[e.hook]) {
-      stats.byHook[e.hook] = { block: 0, allow: 0 };
+      stats.byHook[e.hook] = { block: 0, allow: 0, error: 0 };
     }
     stats.byHook[e.hook][e.decision]++;
   }

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -19,7 +19,7 @@ _log_event() {
     "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" \\
     >> "$_OMH_STATE_DIR/events.jsonl"
 }
-trap '[ "$_OMH_LOGGED" -eq 0 ] && _log_event "allow"' EXIT
+trap '_OMH_EXIT_CODE=$?; if [ "$_OMH_LOGGED" -eq 0 ]; then if [ "$_OMH_EXIT_CODE" -ne 0 ]; then _log_event "error" "hook exited with code $_OMH_EXIT_CODE"; else _log_event "allow"; fi; fi' EXIT
 # --- end logger ---`;
 }
 

--- a/tests/unit/event-logger.test.ts
+++ b/tests/unit/event-logger.test.ts
@@ -114,6 +114,27 @@ describe("readEvents", () => {
     expect(events[1].hook).toBe("file-guard");
   });
 
+  it("'error' decision 이벤트도 정상 파싱", async () => {
+    const stateDir = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(stateDir, { recursive: true });
+    const filePath = path.join(stateDir, "events.jsonl");
+
+    await fs.writeFile(
+      filePath,
+      [
+        '{"ts":"2024-01-01T00:00:00Z","event":"PreToolUse","hook":"tdd-guard","decision":"error","reason":"hook exited with code 127"}',
+        '{"ts":"2024-01-01T00:00:01Z","event":"PreToolUse","hook":"tdd-guard","decision":"allow"}',
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const events = await readEvents(tmpDir);
+    expect(events).toHaveLength(2);
+    expect(events[0].decision).toBe("error");
+    expect(events[0].reason).toBe("hook exited with code 127");
+    expect(events[1].decision).toBe("allow");
+  });
+
   it("필수 필드 누락된 JSON은 무시 (런타임 검증)", async () => {
     const stateDir = path.join(tmpDir, ".claude/hooks/.state");
     await fs.mkdir(stateDir, { recursive: true });
@@ -199,8 +220,24 @@ describe("aggregateStats", () => {
     expect(stats.totalEvents).toBe(4);
     expect(stats.blockCount).toBe(2);
     expect(stats.allowCount).toBe(2);
-    expect(stats.byHook["bash-guard"]).toEqual({ block: 2, allow: 1 });
-    expect(stats.byHook["file-guard"]).toEqual({ block: 0, allow: 1 });
+    expect(stats.byHook["bash-guard"]).toEqual({ block: 2, allow: 1, error: 0 });
+    expect(stats.byHook["file-guard"]).toEqual({ block: 0, allow: 1, error: 0 });
+  });
+
+  it("error decision 포함 집계", () => {
+    const events: HookEvent[] = [
+      { ts: "2024-01-01T00:00:00.000Z", event: "PreToolUse", hook: "tdd-guard", decision: "error", reason: "hook exited with code 127" },
+      { ts: "2024-01-01T00:01:00.000Z", event: "PreToolUse", hook: "tdd-guard", decision: "block" },
+      { ts: "2024-01-01T00:02:00.000Z", event: "PreToolUse", hook: "tdd-guard", decision: "allow" },
+    ];
+
+    const stats = aggregateStats(events);
+
+    expect(stats.totalEvents).toBe(3);
+    expect(stats.errorCount).toBe(1);
+    expect(stats.blockCount).toBe(1);
+    expect(stats.allowCount).toBe(1);
+    expect(stats.byHook["tdd-guard"]).toEqual({ block: 1, allow: 1, error: 1 });
   });
 
   it("빈 배열이면 전부 0", () => {

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -417,6 +417,15 @@ describe("wrapWithLogger", () => {
     expect(result).toContain('_OMH_STATE_DIR="/tmp/my-project/.claude/hooks/.state"');
   });
 
+  it("EXIT trap logs 'error' instead of 'allow' when script exits non-zero", () => {
+    const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
+    const result = wrapWithLogger(script);
+    // The trap must check exit code and log "error" for non-zero exits
+    // instead of unconditionally logging "allow"
+    expect(result).toContain("_OMH_EXIT_CODE=$?");
+    expect(result).toMatch(/error/);
+  });
+
   it("keeps relative _OMH_STATE_DIR when projectDir is omitted", () => {
     const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
     const result = wrapWithLogger(script, "PreToolUse");

--- a/tests/unit/tdd-guard.test.ts
+++ b/tests/unit/tdd-guard.test.ts
@@ -75,11 +75,11 @@ describe("tddGuard block", () => {
     expect(tddGuard.template).toContain("{{srcPattern}}");
   });
 
-  it("generated script uses flock for atomic read-write", () => {
-    // Two concurrent hook processes must not overwrite each other's writes.
-    // The script must use flock (file locking) around the jq read/write operations.
-    expect(tddGuard.template).toMatch(/flock/);
-    // The lock file descriptor redirect pattern: 200> or similar fd redirect
-    expect(tddGuard.template).toMatch(/\d+>.*\.lock/);
+  it("generated script uses tmp+mv for atomic file writes (cross-platform)", () => {
+    // Must NOT use flock (Linux-only, breaks on macOS)
+    expect(tddGuard.template).not.toContain("flock");
+    // Must use tmp file + mv pattern for atomic writes
+    expect(tddGuard.template).toContain(".tmp");
+    expect(tddGuard.template).toContain("mv ");
   });
 });


### PR DESCRIPTION
## Summary
- `tdd-guard` 템플릿에서 Linux 전용 `flock`을 제거하고 `tmp+mv` 기반 atomic write로 대체 (Closes #62)
- hook logger EXIT trap이 비정상 종료(non-zero exit)를 `"allow"`로 잘못 기록하던 문제를 `"error"`로 올바르게 기록하도록 수정

## Root Cause
- `flock`은 `util-linux` 소속으로 macOS에 미포함
- 테스트 파일 기록 경로에서 `flock` 실패 시 `set -euo pipefail`에 의해 스크립트 종료 → edit-history 미생성 → 이후 소스 파일 편집이 항상 차단됨

## Test plan
- [x] Unit: `tdd-guard.test.ts` — 템플릿에 `flock` 미포함 + `tmp+mv` 패턴 검증
- [x] Unit: `hooks-generator.test.ts` — EXIT trap이 non-zero exit 시 `"error"` 기록 검증
- [x] Integration: `tdd-guard-execution.test.ts` — 6개 시나리오 통과 (테스트 기록/소스 허용/토큰 소비/block)
- [x] macOS 실환경 3시나리오 수동 검증 완료
- [x] 전체 테스트 921개 통과, lint 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 파일 동시 접근 문제 해결을 위한 쓰기 메커니즘 개선
* 교차 플랫폼 환경에서의 호환성 강화

## 개선사항
* 프로세스 종료 상태를 실시간으로 감지하여 더욱 정확한 에러 로깅 제공
* 에러 조건에 대한 자동 감지 및 보고 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->