### PR TITLE
chore: release v0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump version to 0.10.2
- Includes fix for #62: tdd-guard macOS flock compatibility
- Includes fix for EXIT trap false-allow logging
- Includes HookEvent "error" decision type extension

## Changes since v0.10.1
- fix: replace flock with tmp+mv for macOS compatibility in tdd-guard (#62)
- fix: EXIT trap logs "error" instead of "allow" on non-zero exit
- fix: extend HookEvent decision type to include "error"
- chore: add .omx/ to .gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)