### PR TITLE
feat: auto-create tag and release on release branch merge

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,37 @@
+name: Auto Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+          echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected version: $VERSION"
+
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
## Summary
- `release/vX.Y.Z` 브랜치가 main에 머지되면 자동으로:
  - `vX.Y.Z` git 태그 생성
  - GitHub Release 생성 (릴리즈 노트 자동 생성)
  - 기존 `publish.yml` CD 파이프라인 자동 트리거

## Flow
```
release/v0.10.2 머지 → auto-release.yml 실행
  → git tag v0.10.2 생성
  → GitHub Release 생성 (--generate-notes)
  → publish.yml 트리거 (v* 태그 감지)
  → npm + GitHub Packages 배포
```

## Test plan
- [x] workflow YAML syntax 검증
- [ ] 다음 릴리즈 머지 시 실제 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)