### PR TITLE
feat: add Android/Kotlin support — tdd-guard, lint-on-save, preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ oh-my-harness init --preset nextjs fastapi
 
 # Short alias works too
 omh init "React app with TDD"
+omh init --preset android            # Android/Kotlin with Hilt, JUnit, Gradle
 omh catalog list
 omh test          # Dry-run verify your harness
 omh stats         # TUI analytics dashboard
@@ -176,7 +177,7 @@ All enforcement is powered by **catalog blocks** — reusable, parameterized hoo
 | 🎨 `format-on-save` | auto-fix | Auto-format on file save |
 | 🧪 `test-on-save` | auto-fix | Auto-run tests on file save |
 | 🔀 `auto-pr` | automation | Auto-create PR after push |
-| 🧪 `tdd-guard` | quality | Blocks source edits unless test modified first (JS/TS/Python) |
+| 🧪 `tdd-guard` | quality | Blocks source edits unless test modified first (JS/TS/Python/Kotlin/Java) |
 | 🔒 `sql-guard` | security | Blocks dangerous SQL operations |
 | 🌳 `worktree-setup` | monorepo | Supports monorepo worktree patterns |
 | 🗜️ `compact-context` | maintenance | Re-injects context on session start |

--- a/presets/android/preset.yaml
+++ b/presets/android/preset.yaml
@@ -56,7 +56,7 @@ hooks:
         COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
         if echo "$COMMAND" | grep -qE "git commit"; then
           echo "oh-my-harness: Running ./gradlew testDebugUnitTest before commit..." >&2
-          if ! ./gradlew testDebugUnitTest >&2 2>&1; then
+          if ! ./gradlew testDebugUnitTest >&2; then
             echo "{\"decision\": \"block\", \"reason\": \"oh-my-harness: unit tests failed, commit blocked\"}"
             exit 0
           fi
@@ -131,10 +131,10 @@ hooks:
           esac
           if [[ -n "$MODULE" ]]; then
             echo "oh-my-harness: Running ${MODULE}:lintDebug..." >&2
-            ./gradlew "${MODULE}:lintDebug" >&2 2>&1 || true
+            ./gradlew "${MODULE}:lintDebug" >&2 || true
           else
             echo "oh-my-harness: Running lintDebug..." >&2
-            ./gradlew lintDebug >&2 2>&1 || true
+            ./gradlew lintDebug >&2 || true
           fi
         fi
         exit 0

--- a/presets/android/preset.yaml
+++ b/presets/android/preset.yaml
@@ -1,0 +1,150 @@
+name: android
+displayName: "Android (Kotlin)"
+description: "Android app with Kotlin, Gradle, Hilt DI, JUnit 4 + Mockito TDD enforcement"
+version: "1.0.0"
+extends: ["gradle"]
+tags: ["android", "kotlin", "mobile", "gradle", "hilt"]
+variables:
+  framework: "android"
+  language: "kotlin"
+  packageManager: "gradle"
+  testRunner: "./gradlew testDebugUnitTest"
+claudeMd:
+  sections:
+    - id: "android-rules"
+      title: "Android Kotlin Rules"
+      content: |
+        ## Android Kotlin Development Rules
+
+        - Use MVVM architecture pattern with ViewModel and LiveData/StateFlow
+        - Use Hilt for dependency injection; avoid manual DI or service locators
+        - Avoid non-null assertion (!!); use safe calls (?.) and let blocks instead
+        - No trailing commas, no wildcard imports
+        - companion object goes first in class member ordering
+        - All state classes must be data class with val properties only
+        - Use ConstraintLayout over nested LinearLayouts for performance
+      priority: 20
+    - id: "android-testing"
+      title: "Android Testing Rules"
+      content: |
+        ## Android Testing Rules
+
+        - Test class naming: [TargetClass]Test (e.g. IoViewTest, RetryPolicyTest)
+        - Test method naming: backtick-wrapped descriptions
+        - Use JUnit 4 + Mockito for unit tests, Espresso for UI tests
+        - Wrap FirebaseCrashlytics calls in try-catch for Robolectric compatibility
+        - Run `./gradlew testDebugUnitTest` before every commit
+      priority: 21
+    - id: "android-build"
+      title: "Android Build Verification"
+      content: |
+        ## Build Verification Rules
+
+        - After code changes, run Kotlin compile check first: `./gradlew :app:compileDebugKotlin`
+        - Then run full APK assembly: `./gradlew assembleDebug`
+        - Kotlin compile passing does NOT guarantee build success (XML resource linking errors)
+      priority: 22
+hooks:
+  preToolUse:
+    - id: "android-test-before-commit"
+      matcher: "Bash"
+      description: "Runs unit tests before git commit"
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+        INPUT=$(cat)
+        COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+        if echo "$COMMAND" | grep -qE "git commit"; then
+          echo "oh-my-harness: Running ./gradlew testDebugUnitTest before commit..." >&2
+          if ! ./gradlew testDebugUnitTest >&2 2>&1; then
+            echo "{\"decision\": \"block\", \"reason\": \"oh-my-harness: unit tests failed, commit blocked\"}"
+            exit 0
+          fi
+        fi
+        exit 0
+    - id: "android-file-guard"
+      matcher: "Edit|Write"
+      description: "Prevents writing to build outputs and sensitive files"
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+        INPUT=$(cat)
+        FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+        [[ -z "$FILE_PATH" ]] && exit 0
+        BASENAME=$(basename "$FILE_PATH")
+        # Block build output directories
+        BLOCKED_DIRS=("build/" ".gradle/" ".idea/")
+        for dir in "${BLOCKED_DIRS[@]}"; do
+          if [[ "$FILE_PATH" == *"/$dir"* ]] || [[ "$FILE_PATH" == "$dir"* ]]; then
+            echo "{\"decision\": \"block\", \"reason\": \"oh-my-harness: protected directory $dir\"}"
+            exit 0
+          fi
+        done
+        # Block build artifacts
+        case "$BASENAME" in
+          *.apk|*.aab) echo "{\"decision\": \"block\", \"reason\": \"oh-my-harness: build artifacts are read-only\"}"; exit 0 ;;
+        esac
+        # Block secret files
+        SECRET_PATTERNS=("local.properties" "*.jks" "*.keystore" "*.pem" "*.key")
+        for pattern in "${SECRET_PATTERNS[@]}"; do
+          if [[ "$BASENAME" == $pattern ]]; then
+            echo "{\"decision\": \"block\", \"reason\": \"oh-my-harness: secret file $BASENAME is protected\"}"
+            exit 0
+          fi
+        done
+        exit 0
+    - id: "android-command-guard"
+      matcher: "Bash"
+      description: "Blocks dangerous commands and release builds"
+      inline: |
+        #!/bin/bash
+        set -euo pipefail
+        INPUT=$(cat)
+        COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+        [[ -z "$COMMAND" ]] && exit 0
+        BLOCKED=("rm -rf /" "sudo rm" "assembleRelease" "bundleRelease")
+        for pattern in "${BLOCKED[@]}"; do
+          if echo "$COMMAND" | grep -qF -- "$pattern"; then
+            echo "{\"decision\": \"block\", \"reason\": \"oh-my-harness: blocked command pattern: $pattern\"}"
+            exit 0
+          fi
+        done
+        exit 0
+  postToolUse:
+    - id: "android-lint-on-save"
+      matcher: "Edit|Write"
+      description: "Runs Android Lint after Kotlin file writes"
+      inline: |
+        #!/bin/bash
+        INPUT=$(cat)
+        FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+        [[ -z "$FILE_PATH" ]] && exit 0
+        BASENAME=$(basename "$FILE_PATH")
+        if [[ "$BASENAME" == *.kt ]]; then
+          # Detect module from file path and run module-scoped lint
+          MODULE=""
+          case "$FILE_PATH" in
+            */app/*) MODULE=":app" ;;
+            */data/*) MODULE=":data" ;;
+            */domain/*) MODULE=":domain" ;;
+            */core/*) MODULE=":core" ;;
+          esac
+          if [[ -n "$MODULE" ]]; then
+            echo "oh-my-harness: Running ${MODULE}:lintDebug..." >&2
+            ./gradlew "${MODULE}:lintDebug" >&2 2>&1 || true
+          else
+            echo "oh-my-harness: Running lintDebug..." >&2
+            ./gradlew lintDebug >&2 2>&1 || true
+          fi
+        fi
+        exit 0
+settings:
+  permissions:
+    allow:
+      - "Bash(./gradlew *)"
+      - "Bash(gradle *)"
+      - "Bash(adb *)"
+      - "Bash(git *)"
+    deny:
+      - "Bash(rm -rf /)"
+      - "Bash(sudo *)"

--- a/src/catalog/blocks/lint-on-save.ts
+++ b/src/catalog/blocks/lint-on-save.ts
@@ -21,6 +21,14 @@ export const lintOnSave: BuildingBlock = {
       description: "Lint command to run (e.g. eslint --fix)",
       required: true,
     },
+    {
+      name: "scope",
+      type: "string",
+      description:
+        "Lint scope: 'file' passes $FILE_PATH to command, 'module' runs command without file arg",
+      required: false,
+      default: "file",
+    },
   ],
   tags: ["lint", "auto-fix", "quality", "save"],
   template: `#!/bin/bash
@@ -31,11 +39,14 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // 
 PATTERN='{{{filePattern}}}'
 BASENAME=$(basename "$FILE_PATH")
 if [[ "$BASENAME" == $PATTERN ]]; then
-  echo "oh-my-harness: Running {{{command}}} ..." >&2
-  # Note: Some linters (e.g. Android Lint, golangci-lint) operate on
-  # project/module scope and do not accept individual file paths.
-  # Pass the file path only when the tool supports it.
-  {{{command}}} >&2 2>&1 || true
+  SCOPE='{{{scope}}}'
+  if [[ "\${SCOPE:-file}" == "module" ]]; then
+    echo "oh-my-harness: Running {{{command}}} ..." >&2
+    {{{command}}} >&2 || true
+  else
+    echo "oh-my-harness: Running {{{command}}} on $FILE_PATH..." >&2
+    {{{command}}} "$FILE_PATH" >&2 || true
+  fi
 fi
 exit 0`,
 };

--- a/src/catalog/blocks/lint-on-save.ts
+++ b/src/catalog/blocks/lint-on-save.ts
@@ -31,8 +31,11 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // 
 PATTERN='{{{filePattern}}}'
 BASENAME=$(basename "$FILE_PATH")
 if [[ "$BASENAME" == $PATTERN ]]; then
-  echo "oh-my-harness: Running {{{command}}} on $FILE_PATH..." >&2
-  {{{command}}} "$FILE_PATH" >&2 2>&1 || true
+  echo "oh-my-harness: Running {{{command}}} ..." >&2
+  # Note: Some linters (e.g. Android Lint, golangci-lint) operate on
+  # project/module scope and do not accept individual file paths.
+  # Pass the file path only when the tool supports it.
+  {{{command}}} >&2 2>&1 || true
 fi
 exit 0`,
 };

--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -73,10 +73,10 @@ fi
 
 # edit-history에서 테스트 파일 검색 (tmp+mv로 원자적 쓰기, 크로스 플랫폼)
 # Supports JS/TS (.test. / .spec. / test_) and JVM (Test suffix, e.g. IoViewTest.kt) conventions
-if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_") or contains("Test")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
+if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_") or endswith("Test.kt") or endswith("Test.java")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
   # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
   UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
-    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_") or contains("Test"))) | not)]
+    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_") or endswith("Test.kt") or endswith("Test.java"))) | not)]
     | .edits += [$f] | .edits |= unique
   ' "\$HISTORY_FILE" 2>/dev/null) || true
   if [[ -n "\$UPDATED" ]]; then

--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -64,19 +64,19 @@ fi
 
 # 대응 테스트 파일 확인 — 확장자 제거
 BASENAME=$(basename "\$FILE_PATH" | sed -E 's/\\.[^.]+$//')
-TEST_SUFFIX=".test."
 
 if [[ ! -f "\$HISTORY_FILE" ]]; then
-  _log_event "block" "oh-my-harness: TDD — \${BASENAME}\${TEST_SUFFIX}* 테스트 파일을 먼저 수정하세요"
-  echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: TDD — \${BASENAME}\${TEST_SUFFIX}* 테스트 파일을 먼저 수정하세요\\"}"
+  _log_event "block" "oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요"
+  echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요\\"}"
   exit 0
 fi
 
 # edit-history에서 테스트 파일 검색 (tmp+mv로 원자적 쓰기, 크로스 플랫폼)
-if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
+# Supports JS/TS (.test. / .spec. / test_) and JVM (Test suffix, e.g. IoViewTest.kt) conventions
+if jq -e --arg b "\$BASENAME" '.edits[] | select(contains($b) and (contains(".test.") or contains(".spec.") or contains("test_") or contains("Test")))' "\$HISTORY_FILE" >/dev/null 2>&1; then
   # 테스트 먼저 수정됨 → 매칭 테스트 기록 소비(제거) + 소스 기록 + 통과
   UPDATED=$(jq --arg b "\$BASENAME" --arg f "\$FILE_PATH" '
-    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_"))) | not)]
+    .edits |= [.[] | select((contains($b) and (contains(".test.") or contains(".spec.") or contains("test_") or contains("Test"))) | not)]
     | .edits += [$f] | .edits |= unique
   ' "\$HISTORY_FILE" 2>/dev/null) || true
   if [[ -n "\$UPDATED" ]]; then
@@ -91,8 +91,8 @@ if [[ "\$DECISION" == "allow" ]]; then
   exit 0
 fi
 
-_log_event "block" "oh-my-harness: TDD — \${BASENAME}\${TEST_SUFFIX}* 테스트 파일을 먼저 수정하세요"
-echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: TDD — \${BASENAME}\${TEST_SUFFIX}* 테스트 파일을 먼저 수정하세요\\"}"
+_log_event "block" "oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요"
+echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요\\"}"
 exit 0`,
   tags: ["tdd", "workflow", "quality"],
 };

--- a/tests/integration/tdd-guard-execution.test.ts
+++ b/tests/integration/tdd-guard-execution.test.ts
@@ -184,3 +184,66 @@ describe("tdd-guard execution", () => {
     },
   );
 });
+
+describe("tdd-guard execution (Kotlin/JVM params)", () => {
+  let tmpDir: string;
+  let scriptPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "omh-tdd-kt-"));
+    // Render with Kotlin/JVM-style patterns
+    const kotlinParams = applyDefaults(tddBlock, {
+      srcPattern: "\\.kt$",
+      testPattern: "Test\\.kt$",
+    });
+    const rendered = renderTemplate(tddBlock.template, kotlinParams);
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    scriptPath = join(tmpDir, "catalog-tdd-guard.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+    await mkdir(join(tmpDir, ".claude/hooks/.state"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it.runIf(hasJq())(
+    "allows Kotlin source edit when JVM-style test file (IoViewTest.kt) was recorded",
+    async () => {
+      const historyPath = join(tmpDir, ".claude/hooks/.state/edit-history.json");
+      await writeFile(
+        historyPath,
+        JSON.stringify({ edits: ["app/src/test/java/com/example/IoViewTest.kt"] }),
+      );
+
+      const stdout = runScript(
+        scriptPath,
+        JSON.stringify({ tool_name: "Edit", tool_input: { file_path: "app/src/main/java/com/example/IoView.kt" } }),
+        tmpDir,
+      );
+      const trimmed = stdout.trim();
+      if (trimmed.length > 0) {
+        const result = JSON.parse(trimmed);
+        expect(result.decision).not.toBe("block");
+      } else {
+        expect(trimmed).toBe("");
+      }
+    },
+  );
+
+  it.runIf(hasJq())(
+    "blocks Kotlin source edit when no prior test recorded",
+    async () => {
+      const stdout = runScript(
+        scriptPath,
+        JSON.stringify({ tool_name: "Edit", tool_input: { file_path: "app/src/main/java/com/example/IoView.kt" } }),
+        tmpDir,
+      );
+      const trimmed = stdout.trim();
+      expect(trimmed).not.toBe("");
+      const result = JSON.parse(trimmed);
+      expect(result.decision).toBe("block");
+      expect(result.reason).toContain("IoView");
+    },
+  );
+});

--- a/tests/unit/tdd-guard.test.ts
+++ b/tests/unit/tdd-guard.test.ts
@@ -49,8 +49,9 @@ describe("tddGuard block", () => {
   });
 
   it("template supports JVM test convention (e.g. IoViewTest.kt)", () => {
-    // Android/Kotlin/Java projects use *Test.kt suffix instead of .test.ts
-    expect(tddGuard.template).toContain('contains("Test")');
+    // Android/Kotlin/Java projects use *Test.kt / *Test.java suffix
+    expect(tddGuard.template).toContain('endswith("Test.kt")');
+    expect(tddGuard.template).toContain('endswith("Test.java")');
   });
 
   it("template allows non-code files to pass through", () => {

--- a/tests/unit/tdd-guard.test.ts
+++ b/tests/unit/tdd-guard.test.ts
@@ -48,6 +48,11 @@ describe("tddGuard block", () => {
     expect(tddGuard.template).toMatch(/\.test\.|\.spec\./);
   });
 
+  it("template supports JVM test convention (e.g. IoViewTest.kt)", () => {
+    // Android/Kotlin/Java projects use *Test.kt suffix instead of .test.ts
+    expect(tddGuard.template).toContain('contains("Test")');
+  });
+
   it("template allows non-code files to pass through", () => {
     expect(tddGuard.template).toMatch(/\.json|\.yaml|\.yml|\.md/);
   });


### PR DESCRIPTION
- Support JVM test convention (*Test.kt) in tdd-guard matching logic
- Remove file path argument from lint-on-save for module-scoped linters
- Add Android preset (Kotlin/Gradle/Hilt guardrails)
- Add unit and integration tests for Kotlin params
- Update README with Android preset example"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * Android (Kotlin) 프리셋 추가로 Android 워크플로우 지원
  * 파일 단위/모듈 단위 린트 실행 범위 옵션 추가
  * JVM 스타일 테스트 명명 규칙(Test.kt/Test.java) 인식 추가

* **Documentation**
  * README에 Android 프리셋 초기화 예제 추가

* **Tests**
  * Kotlin/JVM 통합 및 단위 테스트 추가하여 새 패턴 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->