### PR TITLE
feat: add Codex emitter and unify hooks/state under .omh/

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,22 +70,28 @@ omh stats         # TUI analytics dashboard
 └── config.json                        # AI provider config (global, not per-project)
 
 your-project/
-├── CLAUDE.md                          # TDD rules, coding standards
+├── CLAUDE.md                          # Claude Code instructions (TDD rules, standards)
+├── AGENTS.md                          # Codex CLI instructions (same managed sections)
 ├── harness.yaml                       # Your harness config (source of truth)
-└── .claude/
-    ├── settings.json                  # Hook configs, permissions
-    ├── hooks/
-    │   ├── catalog-branch-guard.sh    # Blocks commits on merged branches
-    │   ├── catalog-tdd-guard.sh       # Enforces test-first workflow
-    │   ├── catalog-commit-test-gate.sh # Tests must pass before commit
-    │   ├── catalog-path-guard.sh      # Protects build outputs
-    │   ├── catalog-command-guard.sh   # Blocks dangerous commands
-    │   ├── catalog-lint-on-save.sh    # Auto-lint on save
-    │   ├── catalog-auto-pr.sh         # Auto-create PR after push
-    │   └── .state/
-    │       ├── events.jsonl           # Hook event log (for analytics)
-    │       └── edit-history.json      # TDD guard state
-    └── oh-my-harness.json             # Active preset tracking
+├── .omh/                              # Single source of truth — hooks + state
+│   ├── hooks/
+│   │   ├── catalog-branch-guard.sh    # Blocks commits on merged branches
+│   │   ├── catalog-tdd-guard.sh       # Enforces test-first workflow
+│   │   ├── catalog-commit-test-gate.sh # Tests must pass before commit
+│   │   ├── catalog-path-guard.sh      # Protects build outputs
+│   │   ├── catalog-command-guard.sh   # Blocks dangerous commands
+│   │   ├── catalog-lint-on-save.sh    # Auto-lint on save
+│   │   └── catalog-auto-pr.sh         # Auto-create PR after push
+│   ├── state/                         # gitignored — log/runtime data
+│   │   ├── events.jsonl               # Unified hook event log (powers omh stats)
+│   │   └── tdd-edits.json             # TDD guard working state
+│   └── manifest.json                  # Generated-files manifest
+├── .claude/
+│   ├── settings.json                  # Claude permissions + hooks → .omh/hooks/*.sh
+│   └── oh-my-harness.json             # Active preset tracking
+└── .codex/
+    ├── config.toml                    # [features] codex_hooks = true
+    └── hooks.json                     # Codex hooks → .omh/hooks/*.sh (same scripts)
 ```
 
 ---
@@ -397,8 +403,9 @@ oh-my-harness/
 - [x] Multi-provider AI support — Claude API, OpenAI, Gemini
 - [x] Interactive model selection per provider
 - [x] GitHub star prompt — first-time only
+- [x] Codex emitter — `AGENTS.md` + `.codex/hooks.json` + `.codex/config.toml`
+- [x] Unified `.omh/` layout — single source of truth for hooks & state across runtimes
 - [ ] Cursor (`.cursor/rules/`) emitter
-- [ ] Codex (`AGENTS.md`) emitter
 - [ ] GitHub Copilot emitter
 - [ ] Community preset registry
 - [ ] `omh modify "change X"` — NL config editing

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ink": "^6.8.0",
         "js-yaml": "^4.1.0",
         "react": "^19.2.4",
+        "smol-toml": "^1.6.1",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -2464,6 +2465,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ink": "^6.8.0",
     "js-yaml": "^4.1.0",
     "react": "^19.2.4",
+    "smol-toml": "^1.6.1",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/src/catalog/blocks/branch-guard.ts
+++ b/src/catalog/blocks/branch-guard.ts
@@ -21,8 +21,9 @@ if echo "$COMMAND" | grep -qE "git commit|git push"; then
   [[ -z "$BRANCH" ]] && exit 0
   MAIN='{{mainBranch}}'
   if [[ "$BRANCH" == "$MAIN" ]] || [[ "$BRANCH" == "master" && "$MAIN" == "main" ]]; then
-    _log_event "block" "oh-my-harness: direct commits to $BRANCH are blocked. Create a feature branch."
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: direct commits to $BRANCH are blocked. Create a feature branch.\\"}"
+    REASON="oh-my-harness: direct commits to $BRANCH are blocked. Create a feature branch."
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
   MERGED=0
@@ -39,8 +40,9 @@ if echo "$COMMAND" | grep -qE "git commit|git push"; then
     fi
   fi
   if [[ "$MERGED" -eq 1 ]]; then
-    _log_event "block" "oh-my-harness: branch $BRANCH has already been merged to $MAIN. Create a new branch."
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: branch $BRANCH has already been merged to $MAIN. Create a new branch.\\"}"
+    REASON="oh-my-harness: branch $BRANCH has already been merged to $MAIN. Create a new branch."
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 fi

--- a/src/catalog/blocks/command-guard.ts
+++ b/src/catalog/blocks/command-guard.ts
@@ -27,8 +27,9 @@ NORMALIZED_CMD=$(printf '%s' "$COMMAND" | tr '[:space:]' ' ' | tr -s ' ')
 PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
 for PATTERN in "\${PATTERNS[@]}"; do
   if echo "$NORMALIZED_CMD" | grep -qF -- "$PATTERN"; then
-    _log_event "block" "oh-my-harness: command matches blocked pattern: $PATTERN"
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: command matches blocked pattern: $PATTERN\\"}"
+    REASON="oh-my-harness: command matches blocked pattern: $PATTERN"
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 done

--- a/src/catalog/blocks/commit-test-gate.ts
+++ b/src/catalog/blocks/commit-test-gate.ts
@@ -19,8 +19,9 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 if echo "$COMMAND" | grep -qE "git commit"; then
   echo "oh-my-harness: Running {{{testCommand}}} before commit..." >&2
   if ! {{{testCommand}}} >&2 2>&1; then
-    _log_event "block" "oh-my-harness: pre-commit check failed"
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: pre-commit check failed\\"}"
+    REASON="oh-my-harness: pre-commit check failed"
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 fi

--- a/src/catalog/blocks/commit-typecheck-gate.ts
+++ b/src/catalog/blocks/commit-typecheck-gate.ts
@@ -19,8 +19,9 @@ COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 if echo "$COMMAND" | grep -qE "git commit"; then
   echo "oh-my-harness: Running {{{typecheckCommand}}} before commit..." >&2
   if ! {{{typecheckCommand}}} >&2 2>&1; then
-    _log_event "block" "oh-my-harness: pre-commit check failed"
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: pre-commit check failed\\"}"
+    REASON="oh-my-harness: pre-commit check failed"
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 fi

--- a/src/catalog/blocks/config-audit.ts
+++ b/src/catalog/blocks/config-audit.ts
@@ -15,7 +15,7 @@ set -euo pipefail
 INPUT=$(cat)
 SOURCE=$(echo "$INPUT" | jq -r '.source // "unknown"' 2>/dev/null)
 FILE=$(echo "$INPUT" | jq -r '.file_path // "unknown"' 2>/dev/null)
-META=$(jq -nc --arg s "$SOURCE" --arg f "$FILE" '{source:$s,file:$f}' 2>/dev/null)
+META=$(jq -nc --arg s "$SOURCE" --arg f "$FILE" '{source:$s,file:$f}' 2>/dev/null || true)
 [ -z "$META" ] && META='{"source":"unknown","file":"unknown"}'
 _log_event "allow" "" "$META"
 exit 0`,

--- a/src/catalog/blocks/config-audit.ts
+++ b/src/catalog/blocks/config-audit.ts
@@ -3,29 +3,20 @@ import type { BuildingBlock } from "../types.js";
 export const configAudit: BuildingBlock = {
   id: "config-audit",
   name: "Config Audit",
-  description: "Logs configuration changes for audit trail",
+  description: "Logs configuration changes into the unified events.jsonl audit trail",
   category: "audit",
   event: "ConfigChange",
   matcher: "",
   canBlock: false,
-  params: [
-    {
-      name: "logFile",
-      type: "string",
-      description: "Path to the audit log file",
-      default: ".claude/hooks/.state/config-audit.log",
-      required: false,
-    },
-  ],
+  params: [],
   tags: ["audit", "config", "logging"],
   template: `#!/bin/bash
 set -euo pipefail
 INPUT=$(cat)
-LOG_FILE="{{{logFile}}}"
-mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 SOURCE=$(echo "$INPUT" | jq -r '.source // "unknown"' 2>/dev/null)
 FILE=$(echo "$INPUT" | jq -r '.file_path // "unknown"' 2>/dev/null)
-TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-echo "{\\"ts\\":\\"$TS\\",\\"source\\":\\"$SOURCE\\",\\"file\\":\\"$FILE\\"}" >> "$LOG_FILE"
+META=$(jq -nc --arg s "$SOURCE" --arg f "$FILE" '{source:$s,file:$f}' 2>/dev/null)
+[ -z "$META" ] && META='{"source":"unknown","file":"unknown"}'
+_log_event "allow" "" "$META"
 exit 0`,
 };

--- a/src/catalog/blocks/lockfile-guard.ts
+++ b/src/catalog/blocks/lockfile-guard.ts
@@ -27,8 +27,9 @@ BASENAME=$(basename "$FILE_PATH")
 LOCKFILES=({{#each lockfiles}}"{{{this}}}" {{/each}})
 for LOCKFILE in "\${LOCKFILES[@]}"; do
   if [[ "$BASENAME" == "$LOCKFILE" ]]; then
-    _log_event "block" "oh-my-harness: direct edits to lockfile $BASENAME are blocked. Use the package manager instead."
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: direct edits to lockfile $BASENAME are blocked. Use the package manager instead.\\"}"
+    REASON="oh-my-harness: direct edits to lockfile $BASENAME are blocked. Use the package manager instead."
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 done

--- a/src/catalog/blocks/path-guard.ts
+++ b/src/catalog/blocks/path-guard.ts
@@ -25,15 +25,17 @@ FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // 
 # Normalize path to prevent directory traversal attacks (e.g., ./foo/../dist/secret.js -> dist/secret.js)
 if command -v python3 >/dev/null 2>&1; then
   if ! NORMALIZED=$(python3 -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null); then
-    _log_event "block" "oh-my-harness: path normalization unavailable for non-canonical path"
-    echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: path normalization unavailable for non-canonical path\\\"}"
+    REASON="oh-my-harness: path normalization unavailable for non-canonical path"
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 else
   case "$FILE_PATH" in
     /*|../*|*/../*|*/..|./*|*/./*|*/.)
-      _log_event "block" "oh-my-harness: path normalization unavailable for non-canonical path"
-      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: path normalization unavailable for non-canonical path\\\"}"
+      REASON="oh-my-harness: path normalization unavailable for non-canonical path"
+      _log_event "block" "$REASON"
+      _emit_decision "block" "$REASON"
       exit 0
       ;;
   esac
@@ -43,21 +45,24 @@ BLOCKED_PATHS=({{#each blockedPaths}}"{{{this}}}" {{/each}})
 for BLOCKED in "\${BLOCKED_PATHS[@]}"; do
   if [[ "$BLOCKED" == */ ]]; then
     if [[ "$NORMALIZED" == "$BLOCKED"* || "$NORMALIZED" == *"/$BLOCKED"* ]]; then
-      _log_event "block" "oh-my-harness: file path matches blocked directory: $BLOCKED"
-      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: file path matches blocked directory: $BLOCKED\\\"}"
+      REASON="oh-my-harness: file path matches blocked directory: $BLOCKED"
+      _log_event "block" "$REASON"
+      _emit_decision "block" "$REASON"
       exit 0
     fi
   elif [[ "$BLOCKED" == \\** ]]; then
     PATTERN="\${BLOCKED#\\*}"
     if [[ "$NORMALIZED" == *"$PATTERN" ]]; then
-      _log_event "block" "oh-my-harness: file path matches blocked pattern: $BLOCKED"
-      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: file path matches blocked pattern: $BLOCKED\\\"}"
+      REASON="oh-my-harness: file path matches blocked pattern: $BLOCKED"
+      _log_event "block" "$REASON"
+      _emit_decision "block" "$REASON"
       exit 0
     fi
   else
     if [[ "$NORMALIZED" == "$BLOCKED" || "$NORMALIZED" == *"/$BLOCKED" ]]; then
-      _log_event "block" "oh-my-harness: file path matches blocked path: $BLOCKED"
-      echo "{\\"decision\\": \\\"block\\\", \\\"reason\\\": \\\"oh-my-harness: file path matches blocked path: $BLOCKED\\\"}"
+      REASON="oh-my-harness: file path matches blocked path: $BLOCKED"
+      _log_event "block" "$REASON"
+      _emit_decision "block" "$REASON"
       exit 0
     fi
   fi

--- a/src/catalog/blocks/secret-file-guard.ts
+++ b/src/catalog/blocks/secret-file-guard.ts
@@ -27,8 +27,9 @@ BASENAME=$(basename "$FILE_PATH")
 PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
 for PATTERN in "\${PATTERNS[@]}"; do
   if [[ "$BASENAME" == $PATTERN ]]; then
-    _log_event "block" "oh-my-harness: file $BASENAME matches secret file pattern: $PATTERN"
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: file $BASENAME matches secret file pattern: $PATTERN\\"}"
+    REASON="oh-my-harness: file $BASENAME matches secret file pattern: $PATTERN"
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 done

--- a/src/catalog/blocks/sql-guard.ts
+++ b/src/catalog/blocks/sql-guard.ts
@@ -28,7 +28,9 @@ PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
 for PATTERN in "\${PATTERNS[@]}"; do
   PATTERN_LOWER=$(echo "$PATTERN" | tr '[:upper:]' '[:lower:]')
   if echo "$COMMAND_LOWER" | grep -qF -- "$PATTERN_LOWER"; then
-    _emit_decision "block" "oh-my-harness: SQL command matches blocked pattern: $PATTERN"
+    REASON="oh-my-harness: SQL command matches blocked pattern: $PATTERN"
+    _log_event "block" "$REASON"
+    _emit_decision "block" "$REASON"
     exit 0
   fi
 done

--- a/src/catalog/blocks/sql-guard.ts
+++ b/src/catalog/blocks/sql-guard.ts
@@ -28,7 +28,7 @@ PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
 for PATTERN in "\${PATTERNS[@]}"; do
   PATTERN_LOWER=$(echo "$PATTERN" | tr '[:upper:]' '[:lower:]')
   if echo "$COMMAND_LOWER" | grep -qF -- "$PATTERN_LOWER"; then
-    echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: SQL command matches blocked pattern: $PATTERN\\"}"
+    _emit_decision "block" "oh-my-harness: SQL command matches blocked pattern: $PATTERN"
     exit 0
   fi
 done

--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -65,9 +65,10 @@ fi
 # 대응 테스트 파일 확인 — 확장자 제거
 BASENAME=$(basename "\$FILE_PATH" | sed -E 's/\\.[^.]+$//')
 
+REASON="oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요"
 if [[ ! -f "\$HISTORY_FILE" ]]; then
-  _log_event "block" "oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요"
-  echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요\\"}"
+  _log_event "block" "\$REASON"
+  _emit_decision "block" "\$REASON"
   exit 0
 fi
 
@@ -91,8 +92,8 @@ if [[ "\$DECISION" == "allow" ]]; then
   exit 0
 fi
 
-_log_event "block" "oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요"
-echo "{\\"decision\\": \\"block\\", \\"reason\\": \\"oh-my-harness: TDD — \${BASENAME} 에 대응하는 테스트 파일을 먼저 수정하세요\\"}"
+_log_event "block" "\$REASON"
+_emit_decision "block" "\$REASON"
 exit 0`,
   tags: ["tdd", "workflow", "quality"],
 };

--- a/src/catalog/blocks/tdd-guard.ts
+++ b/src/catalog/blocks/tdd-guard.ts
@@ -35,9 +35,9 @@ case "\$FILE_PATH" in
   *.json|*.yaml|*.yml|*.md|*.sh|*.css|*.html|*.svg|*.png|*.jpg) exit 0 ;;
 esac
 
-# edit-history 상태 파일
-STATE_DIR=".claude/hooks/.state"
-HISTORY_FILE="\$STATE_DIR/edit-history.json"
+# edit-history 상태 파일 (logger wrapper가 _OMH_STATE_DIR 를 export)
+STATE_DIR="\${_OMH_STATE_DIR:-.omh/state}"
+HISTORY_FILE="\$STATE_DIR/tdd-edits.json"
 mkdir -p "\$STATE_DIR" 2>/dev/null || true
 
 TEST_RE='{{{testPattern}}}'

--- a/src/catalog/converter.ts
+++ b/src/catalog/converter.ts
@@ -1,6 +1,7 @@
 import type { HookEntry } from "./types.js";
 import type { CatalogRegistry } from "./registry.js";
 import { renderTemplate, validateParams, applyDefaults } from "./template-engine.js";
+import { OMH_HOOKS_DIR } from "../utils/paths.js";
 
 export interface HookConfigEntry {
   type: "command";
@@ -51,7 +52,7 @@ export async function convertHookEntries(
     const count = blockInstanceCount.get(entry.block) ?? 0;
     blockInstanceCount.set(entry.block, count + 1);
     const scriptName = count === 0 ? `${entry.block}.sh` : `${entry.block}-${count}.sh`;
-    const scriptPath = `.claude/hooks/${scriptName}`;
+    const scriptPath = `${OMH_HOOKS_DIR}/${scriptName}`;
     scripts.set(scriptPath, scriptContent);
 
     const hookEntry: HookConfigEntry = {

--- a/src/cli/command-checker.ts
+++ b/src/cli/command-checker.ts
@@ -79,7 +79,7 @@ export async function checkHarnessCommands(
   const path = await import("node:path");
 
   for (const hook of hooks) {
-    const scriptPath = hook.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "");
+    const scriptPath = hook.command.replace(/^bash\s+/, "").replace(/^['"]|['"]$/g, "");
     const fullPath = path.join(projectDir, scriptPath);
 
     let content: string;

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { parse } from "smol-toml";
 import { OMH_HOOKS_DIR } from "../../utils/paths.js";
 
 export interface DoctorOptions {
@@ -85,7 +86,8 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
   try {
     await fs.access(codexHooksPath);
     const tomlRaw = await fs.readFile(codexTomlPath, "utf-8");
-    if (!tomlRaw.includes("codex_hooks = true")) {
+    const parsed = parse(tomlRaw) as { features?: { codex_hooks?: unknown } };
+    if (parsed.features?.codex_hooks !== true) {
       messages.push("FAIL: .codex/config.toml missing [features] codex_hooks = true.");
     } else {
       checks.codexConfig = true;
@@ -94,7 +96,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       messages.push("FAIL: .codex/hooks.json or .codex/config.toml not found.");
     } else {
-      messages.push("FAIL: .codex/config.toml unreadable.");
+      messages.push("FAIL: .codex/config.toml invalid or unreadable.");
     }
   }
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { OMH_HOOKS_DIR } from "../../utils/paths.js";
 
 export interface DoctorOptions {
   projectDir?: string;
@@ -11,7 +12,9 @@ export interface DoctorResult {
   checks: {
     stateFile: boolean;
     claudeMd: boolean;
+    agentsMd: boolean;
     settingsJson: boolean;
+    codexConfig: boolean;
     hooksExecutable: boolean;
   };
   messages: string[];
@@ -24,7 +27,9 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
   const checks = {
     stateFile: false,
     claudeMd: false,
+    agentsMd: false,
     settingsJson: false,
+    codexConfig: false,
     hooksExecutable: false,
   };
 
@@ -65,8 +70,36 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
     }
   }
 
-  // 4. Check hook scripts exist and are executable
-  const hooksDir = path.join(projectDir, ".claude", "hooks");
+  // 4. AGENTS.md (Codex)
+  const agentsMdPath = path.join(projectDir, "AGENTS.md");
+  try {
+    await fs.access(agentsMdPath);
+    checks.agentsMd = true;
+  } catch {
+    messages.push("FAIL: AGENTS.md not found.");
+  }
+
+  // 5. .codex/hooks.json + .codex/config.toml
+  const codexHooksPath = path.join(projectDir, ".codex", "hooks.json");
+  const codexTomlPath = path.join(projectDir, ".codex", "config.toml");
+  try {
+    await fs.access(codexHooksPath);
+    const tomlRaw = await fs.readFile(codexTomlPath, "utf-8");
+    if (!tomlRaw.includes("codex_hooks = true")) {
+      messages.push("FAIL: .codex/config.toml missing [features] codex_hooks = true.");
+    } else {
+      checks.codexConfig = true;
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      messages.push("FAIL: .codex/hooks.json or .codex/config.toml not found.");
+    } else {
+      messages.push("FAIL: .codex/config.toml unreadable.");
+    }
+  }
+
+  // 6. Check hook scripts exist and are executable
+  const hooksDir = path.join(projectDir, OMH_HOOKS_DIR);
   try {
     const files = await fs.readdir(hooksDir);
     const scripts = files.filter((f) => f.endsWith(".sh"));

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -80,11 +80,11 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
     messages.push("FAIL: AGENTS.md not found.");
   }
 
-  // 5. .codex/hooks.json + .codex/config.toml
+  // 5. .codex/hooks.json + .codex/config.toml — both must exist AND parse.
   const codexHooksPath = path.join(projectDir, ".codex", "hooks.json");
   const codexTomlPath = path.join(projectDir, ".codex", "config.toml");
   try {
-    await fs.access(codexHooksPath);
+    JSON.parse(await fs.readFile(codexHooksPath, "utf-8"));
     const tomlRaw = await fs.readFile(codexTomlPath, "utf-8");
     const parsed = parse(tomlRaw) as { features?: { codex_hooks?: unknown } };
     if (parsed.features?.codex_hooks !== true) {
@@ -96,7 +96,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       messages.push("FAIL: .codex/hooks.json or .codex/config.toml not found.");
     } else {
-      messages.push("FAIL: .codex/config.toml invalid or unreadable.");
+      messages.push("FAIL: .codex/hooks.json or .codex/config.toml is invalid or unreadable.");
     }
   }
 

--- a/src/cli/event-logger.ts
+++ b/src/cli/event-logger.ts
@@ -12,21 +12,18 @@ export interface HookEvent {
   meta?: Record<string, unknown>;
 }
 
-const STATE_DIR = OMH_STATE_DIR;
-const EVENTS_FILE = OMH_EVENTS_FILE;
-
 export async function appendEvent(
   projectDir: string,
   hookEvent: HookEvent,
 ): Promise<void> {
-  const stateDir = path.join(projectDir, STATE_DIR);
+  const stateDir = path.join(projectDir, OMH_STATE_DIR);
   await fs.mkdir(stateDir, { recursive: true });
-  const filePath = path.join(stateDir, EVENTS_FILE);
+  const filePath = path.join(stateDir, OMH_EVENTS_FILE);
   await fs.appendFile(filePath, JSON.stringify(hookEvent) + "\n", "utf-8");
 }
 
 export async function readEvents(projectDir: string): Promise<HookEvent[]> {
-  const filePath = path.join(projectDir, STATE_DIR, EVENTS_FILE);
+  const filePath = path.join(projectDir, OMH_STATE_DIR, OMH_EVENTS_FILE);
   let content: string;
   try {
     content = await fs.readFile(filePath, "utf-8");

--- a/src/cli/event-logger.ts
+++ b/src/cli/event-logger.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { OMH_STATE_DIR, OMH_EVENTS_FILE } from "../utils/paths.js";
 
 export interface HookEvent {
   ts: string;
@@ -8,10 +9,11 @@ export interface HookEvent {
   decision: "block" | "allow" | "error";
   reason?: string;
   tool?: string;
+  meta?: Record<string, unknown>;
 }
 
-const STATE_DIR = ".claude/hooks/.state";
-const EVENTS_FILE = "events.jsonl";
+const STATE_DIR = OMH_STATE_DIR;
+const EVENTS_FILE = OMH_EVENTS_FILE;
 
 export async function appendEvent(
   projectDir: string,

--- a/src/cli/harness-tester.ts
+++ b/src/cli/harness-tester.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { HookEntry, BuildingBlock } from "../catalog/types.js";
 import { applyDefaults } from "../catalog/template-engine.js";
+import { OMH_HOOKS_DIR, OMH_STATE_DIR, OMH_TDD_STATE_FILE } from "../utils/paths.js";
 
 export interface HookInput {
   tool_name: string;
@@ -184,7 +185,7 @@ export function generateBlockTestCases(
     });
     const hookScript = matchedHook
       ? matchedHook.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "")
-      : `.claude/hooks/catalog-${block.id}.sh`;
+      : `${OMH_HOOKS_DIR}/catalog-${block.id}.sh`;
 
     switch (block.id) {
       case "path-guard": {
@@ -286,7 +287,7 @@ export function generateBlockTestCases(
       }
 
       case "tdd-guard": {
-        const stateFile = ".claude/hooks/.state/edit-history.json";
+        const stateFile = `${OMH_STATE_DIR}/${OMH_TDD_STATE_FILE}`;
         const srcPat = (params.srcPattern as string) ?? "\\.(ts|tsx|js|jsx)$";
         const testPat = (params.testPattern as string) ?? "\\.(test|spec)\\.(ts|tsx|js|jsx)$";
         // Derive sample file extensions from patterns

--- a/src/cli/harness-tester.ts
+++ b/src/cli/harness-tester.ts
@@ -180,11 +180,11 @@ export function generateBlockTestCases(
     };
     const aliases = blockIdAliases[block.id] ?? [block.id];
     const matchedHook = registeredHooks?.find((h) => {
-      const scriptName = h.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "");
+      const scriptName = h.command.replace(/^bash\s+/, "").replace(/^['"]|['"]$/g, "");
       return aliases.some((alias) => scriptName.includes(alias));
     });
     const hookScript = matchedHook
-      ? matchedHook.command.replace(/^bash\s+/, "").replace(/^"|"$/g, "")
+      ? matchedHook.command.replace(/^bash\s+/, "").replace(/^['"]|['"]$/g, "")
       : `${OMH_HOOKS_DIR}/catalog-${block.id}.sh`;
 
     switch (block.id) {

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -24,27 +24,27 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
   // One-time migration of legacy .claude/hooks/.state → .omh/state
   await migrateLegacyState(projectDir);
 
-  // Generate CLAUDE.md (Claude Code instructions)
-  await generateClaudeMd({ projectDir, config });
-  files.push(`${projectDir}/CLAUDE.md`);
+  // CLAUDE.md and AGENTS.md operate on disjoint files with the same input.
+  await Promise.all([
+    generateClaudeMd({ projectDir, config }),
+    generateAgentsMd({ projectDir, config }),
+  ]);
+  files.push(`${projectDir}/CLAUDE.md`, `${projectDir}/AGENTS.md`);
 
-  // Generate AGENTS.md (Codex instructions, same managed sections)
-  await generateAgentsMd({ projectDir, config });
-  files.push(`${projectDir}/AGENTS.md`);
-
-  // Generate hook scripts (single source under .omh/hooks)
+  // Hook scripts (single source under .omh/hooks). Settings + Codex both
+  // depend on hooksOutput, so this stage runs first.
   const hooksOutput = await generateHooks({ projectDir, config });
   files.push(...hooksOutput.generatedFiles);
 
-  // Generate Claude settings.json (references .omh/hooks/*.sh)
-  await generateSettings({ projectDir, config, hooksOutput });
-  files.push(`${projectDir}/.claude/settings.json`);
+  // Claude settings.json and Codex config write to disjoint files using the
+  // same hooksOutput — independent.
+  const [, codexFiles] = await Promise.all([
+    generateSettings({ projectDir, config, hooksOutput }),
+    generateCodexConfig({ projectDir, hooksOutput }),
+  ]);
+  files.push(`${projectDir}/.claude/settings.json`, ...codexFiles);
 
-  // Generate Codex config (references same .omh/hooks/*.sh)
-  const codexFiles = await generateCodexConfig({ projectDir, hooksOutput });
-  files.push(...codexFiles);
-
-  // Update .gitignore — only state is volatile log data; hooks/manifest are reproducible
+  // .omh/state/ holds volatile log data; hooks/manifest are reproducible.
   await updateGitignore(projectDir, [`${OMH_DIR}/state/`]);
   files.push(`${projectDir}/.gitignore`);
 

--- a/src/core/generator.ts
+++ b/src/core/generator.ts
@@ -1,8 +1,12 @@
 import type { MergedConfig } from "./preset-types.js";
 import { generateClaudeMd } from "../generators/claude-md.js";
+import { generateAgentsMd } from "../generators/agents-md.js";
 import { generateHooks } from "../generators/hooks.js";
 import { generateSettings } from "../generators/settings.js";
+import { generateCodexConfig } from "../generators/codex-config.js";
 import { updateGitignore } from "../generators/gitignore.js";
+import { migrateLegacyState } from "../utils/state-migration.js";
+import { OMH_DIR } from "../utils/paths.js";
 
 export interface GenerateOptions {
   projectDir: string;
@@ -17,20 +21,31 @@ export async function generate(options: GenerateOptions): Promise<GenerateResult
   const { projectDir, config } = options;
   const files: string[] = [];
 
-  // Generate CLAUDE.md
+  // One-time migration of legacy .claude/hooks/.state → .omh/state
+  await migrateLegacyState(projectDir);
+
+  // Generate CLAUDE.md (Claude Code instructions)
   await generateClaudeMd({ projectDir, config });
   files.push(`${projectDir}/CLAUDE.md`);
 
-  // Generate hook scripts
+  // Generate AGENTS.md (Codex instructions, same managed sections)
+  await generateAgentsMd({ projectDir, config });
+  files.push(`${projectDir}/AGENTS.md`);
+
+  // Generate hook scripts (single source under .omh/hooks)
   const hooksOutput = await generateHooks({ projectDir, config });
   files.push(...hooksOutput.generatedFiles);
 
-  // Generate settings.json (needs hooks output for hooks config)
+  // Generate Claude settings.json (references .omh/hooks/*.sh)
   await generateSettings({ projectDir, config, hooksOutput });
   files.push(`${projectDir}/.claude/settings.json`);
 
-  // Update .gitignore
-  await updateGitignore(projectDir, [".claude/hooks/", ".claude/hooks/.state/"]);
+  // Generate Codex config (references same .omh/hooks/*.sh)
+  const codexFiles = await generateCodexConfig({ projectDir, hooksOutput });
+  files.push(...codexFiles);
+
+  // Update .gitignore — only state is volatile log data; hooks/manifest are reproducible
+  await updateGitignore(projectDir, [`${OMH_DIR}/state/`]);
   files.push(`${projectDir}/.gitignore`);
 
   return { files };

--- a/src/core/harness-converter-v2.ts
+++ b/src/core/harness-converter-v2.ts
@@ -53,7 +53,7 @@ export async function harnessToMergedConfigV2(
     }
 
     for (const entry of entries) {
-      // Find the block id from the script path: .claude/hooks/<block-id>.sh
+      // Find the block id from the script path: <hooks-dir>/<block-id>.sh
       const blockId = entry.command.replace(/.*\/(.+)\.sh$/, "$1");
       const hookDef: HookDefinition = {
         id: `catalog-${blockId}`,

--- a/src/generators/agents-md.ts
+++ b/src/generators/agents-md.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { MergedConfig } from "../core/preset-types.js";
+import { extractManagedSections, removeManagedSection, upsertManagedSection } from "../utils/markdown.js";
+
+export interface GenerateAgentsMdOptions {
+  projectDir: string;
+  config: MergedConfig;
+}
+
+export async function generateAgentsMd(options: GenerateAgentsMdOptions): Promise<string> {
+  const { projectDir, config } = options;
+  const agentsMdPath = path.join(projectDir, "AGENTS.md");
+
+  let content: string;
+  try {
+    content = await fs.readFile(agentsMdPath, "utf8");
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code === "ENOENT") {
+      content = "";
+    } else {
+      throw error;
+    }
+  }
+
+  const currentIds = new Set(config.claudeMdSections.map((s) => s.id));
+  const existingIds = extractManagedSections(content).map((s) => s.id);
+  for (const id of existingIds) {
+    if (!currentIds.has(id)) {
+      content = removeManagedSection(content, id);
+    }
+  }
+
+  const sections = [...config.claudeMdSections].sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50));
+
+  for (const section of sections) {
+    const sectionContent = section.content ?? "";
+    content = upsertManagedSection(content, section.id, sectionContent);
+  }
+
+  await fs.writeFile(agentsMdPath, content, "utf8");
+  return content;
+}

--- a/src/generators/agents-md.ts
+++ b/src/generators/agents-md.ts
@@ -24,13 +24,17 @@ export async function generateAgentsMd(options: GenerateAgentsMdOptions): Promis
     }
   }
 
-  const currentIds = new Set(config.claudeMdSections.map((s) => s.id));
+  // Strip ALL managed sections (including those still in config) so the
+  // re-insertion below honors the new priority order. upsertManagedSection
+  // does in-place replace when the marker exists, which would otherwise
+  // freeze the original ordering.
   const existingIds = extractManagedSections(content).map((s) => s.id);
   for (const id of existingIds) {
-    if (!currentIds.has(id)) {
-      content = removeManagedSection(content, id);
-    }
+    content = removeManagedSection(content, id);
   }
+  // Normalize whitespace so repeated stripping doesn't accumulate blank lines.
+  content = content.replace(/^\n+/, "").replace(/\n+$/, "");
+  if (content) content += "\n";
 
   const sections = [...config.claudeMdSections].sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50));
 

--- a/src/generators/agents-md.ts
+++ b/src/generators/agents-md.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
-import { extractManagedSections, removeManagedSection, upsertManagedSection } from "../utils/markdown.js";
+import { writeManagedMarkdown } from "./managed-md.js";
 
 export interface GenerateAgentsMdOptions {
   projectDir: string;
@@ -9,40 +8,8 @@ export interface GenerateAgentsMdOptions {
 }
 
 export async function generateAgentsMd(options: GenerateAgentsMdOptions): Promise<string> {
-  const { projectDir, config } = options;
-  const agentsMdPath = path.join(projectDir, "AGENTS.md");
-
-  let content: string;
-  try {
-    content = await fs.readFile(agentsMdPath, "utf8");
-  } catch (err) {
-    const error = err as NodeJS.ErrnoException;
-    if (error.code === "ENOENT") {
-      content = "";
-    } else {
-      throw error;
-    }
-  }
-
-  // Strip ALL managed sections (including those still in config) so the
-  // re-insertion below honors the new priority order. upsertManagedSection
-  // does in-place replace when the marker exists, which would otherwise
-  // freeze the original ordering.
-  const existingIds = extractManagedSections(content).map((s) => s.id);
-  for (const id of existingIds) {
-    content = removeManagedSection(content, id);
-  }
-  // Normalize whitespace so repeated stripping doesn't accumulate blank lines.
-  content = content.replace(/^\n+/, "").replace(/\n+$/, "");
-  if (content) content += "\n";
-
-  const sections = [...config.claudeMdSections].sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50));
-
-  for (const section of sections) {
-    const sectionContent = section.content ?? "";
-    content = upsertManagedSection(content, section.id, sectionContent);
-  }
-
-  await fs.writeFile(agentsMdPath, content, "utf8");
-  return content;
+  return writeManagedMarkdown(
+    path.join(options.projectDir, "AGENTS.md"),
+    options.config.claudeMdSections,
+  );
 }

--- a/src/generators/claude-md.ts
+++ b/src/generators/claude-md.ts
@@ -25,14 +25,18 @@ export async function generateClaudeMd(options: GenerateClaudeMdOptions): Promis
     }
   }
 
-  // Remove managed sections that are no longer in the current config
-  const currentIds = new Set(config.claudeMdSections.map((s) => s.id));
+  // Strip ALL managed sections (including those still in config) so the
+  // re-insertion below honors the new priority order. upsertManagedSection
+  // does in-place replace when the marker exists, which would otherwise
+  // freeze the original ordering.
   const existingIds = extractManagedSections(content).map((s) => s.id);
   for (const id of existingIds) {
-    if (!currentIds.has(id)) {
-      content = removeManagedSection(content, id);
-    }
+    content = removeManagedSection(content, id);
   }
+  // Normalize whitespace so repeated stripping doesn't accumulate blank lines
+  // at the file edges (otherwise idempotency breaks across runs).
+  content = content.replace(/^\n+/, "").replace(/\n+$/, "");
+  if (content) content += "\n";
 
   // Sort sections by priority (lower = higher in file)
   const sections = [...config.claudeMdSections].sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50));

--- a/src/generators/claude-md.ts
+++ b/src/generators/claude-md.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
-import { extractManagedSections, removeManagedSection, upsertManagedSection } from "../utils/markdown.js";
+import { writeManagedMarkdown } from "./managed-md.js";
 
 export interface GenerateClaudeMdOptions {
   projectDir: string;
@@ -9,44 +8,8 @@ export interface GenerateClaudeMdOptions {
 }
 
 export async function generateClaudeMd(options: GenerateClaudeMdOptions): Promise<string> {
-  const { projectDir, config } = options;
-  const claudeMdPath = path.join(projectDir, "CLAUDE.md");
-
-  // Read existing content or start fresh
-  let content: string;
-  try {
-    content = await fs.readFile(claudeMdPath, "utf8");
-  } catch (err) {
-    const error = err as NodeJS.ErrnoException;
-    if (error.code === "ENOENT") {
-      content = "";
-    } else {
-      throw error;
-    }
-  }
-
-  // Strip ALL managed sections (including those still in config) so the
-  // re-insertion below honors the new priority order. upsertManagedSection
-  // does in-place replace when the marker exists, which would otherwise
-  // freeze the original ordering.
-  const existingIds = extractManagedSections(content).map((s) => s.id);
-  for (const id of existingIds) {
-    content = removeManagedSection(content, id);
-  }
-  // Normalize whitespace so repeated stripping doesn't accumulate blank lines
-  // at the file edges (otherwise idempotency breaks across runs).
-  content = content.replace(/^\n+/, "").replace(/\n+$/, "");
-  if (content) content += "\n";
-
-  // Sort sections by priority (lower = higher in file)
-  const sections = [...config.claudeMdSections].sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50));
-
-  // Upsert each section in priority order
-  for (const section of sections) {
-    const sectionContent = section.content ?? "";
-    content = upsertManagedSection(content, section.id, sectionContent);
-  }
-
-  await fs.writeFile(claudeMdPath, content, "utf8");
-  return content;
+  return writeManagedMarkdown(
+    path.join(options.projectDir, "CLAUDE.md"),
+    options.config.claudeMdSections,
+  );
 }

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -58,23 +58,43 @@ export function buildCodexHooks(hooksOutput: HooksOutput): {
   return { codexHooks, skipped };
 }
 
+const MARKER_RE = new RegExp(`${CONFIG_MARKER_START}[\\s\\S]*?${CONFIG_MARKER_END}\\n?`);
+const FEATURES_HEADER_RE = /^\[features\]\s*$/m;
+
+const INLINE_BLOCK =
+  `${CONFIG_MARKER_START}\n` +
+  `codex_hooks = true\n` +
+  `${CONFIG_MARKER_END}`;
+
+const STANDALONE_BLOCK =
+  `${CONFIG_MARKER_START}\n` +
+  `[features]\n` +
+  `codex_hooks = true\n` +
+  `${CONFIG_MARKER_END}\n`;
+
 export function buildCodexConfigToml(existing: string): string {
-  const managedBlock =
-    `${CONFIG_MARKER_START}\n` +
-    `[features]\n` +
-    `codex_hooks = true\n` +
-    `${CONFIG_MARKER_END}\n`;
+  // Step 1: strip any prior managed marker block so we can re-place it
+  // correctly without leaving stale duplicates behind.
+  const stripped = existing.replace(MARKER_RE, "").replace(/\n{3,}/g, "\n\n");
 
-  if (!existing) {
-    return CODEX_CONFIG_HEADER + managedBlock;
+  // Step 2: empty input → emit a standalone block with our own [features].
+  if (!stripped.trim()) {
+    return CODEX_CONFIG_HEADER + STANDALONE_BLOCK;
   }
 
-  const re = new RegExp(`${CONFIG_MARKER_START}[\\s\\S]*?${CONFIG_MARKER_END}\\n?`);
-  if (re.test(existing)) {
-    return existing.replace(re, managedBlock);
+  // Step 3: user already declared [features] elsewhere in the file. We must
+  // NOT add a second [features] header (TOML v1.0 forbids redefining tables).
+  // Inject our key inside the existing table.
+  if (FEATURES_HEADER_RE.test(stripped)) {
+    return stripped.replace(
+      FEATURES_HEADER_RE,
+      (match) => `${match}\n${INLINE_BLOCK}`,
+    );
   }
-  const sep = existing.endsWith("\n") ? "" : "\n";
-  return existing + sep + managedBlock;
+
+  // Step 4: user content but no [features] yet → append our standalone block.
+  const sep = stripped.endsWith("\n") ? "" : "\n";
+  return stripped + sep + STANDALONE_BLOCK;
 }
 
 export async function generateCodexConfig(options: GenerateCodexConfigOptions): Promise<string[]> {

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -90,7 +90,11 @@ export function buildCodexConfigToml(existing: string): string {
     }
   }
 
-  const features = (data.features as Record<string, unknown> | undefined) ?? {};
+  // `features` may be missing, a scalar (e.g. `features = true`), or an
+  // array — only treat it as an existing table when it actually is one.
+  const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+    v !== null && typeof v === "object" && !Array.isArray(v);
+  const features = isPlainObject(data.features) ? data.features : {};
   features.codex_hooks = true;
   data.features = features;
 

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -78,11 +78,14 @@ export function buildCodexConfigToml(existing: string): string {
   if (existing.trim()) {
     try {
       data = parse(existing) as Record<string, unknown>;
-    } catch {
-      // Malformed user TOML: start fresh. We don't write back if the result
-      // matches `existing` (see generateCodexConfig), so an unrelated parse
-      // error doesn't silently destroy data — only an actual edit triggers
-      // a write, and at that point `existing` is broken anyway.
+    } catch (err) {
+      // Malformed user TOML: warn so the user knows we're regenerating, then
+      // start fresh. (generateCodexConfig still skips the write when the new
+      // content equals `existing`, so this only kicks in for actual edits.)
+      console.warn(
+        `oh-my-harness: .codex/config.toml is invalid TOML, regenerating ` +
+          `from scratch — original content will be replaced. (${(err as Error).message})`,
+      );
       data = {};
     }
   }

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { HooksOutput } from "./hooks.js";
+
+export interface GenerateCodexConfigOptions {
+  projectDir: string;
+  hooksOutput: HooksOutput;
+}
+
+const CODEX_SUPPORTED_EVENTS = new Set([
+  "SessionStart",
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "PermissionRequest",
+  "Stop",
+]);
+
+const CODEX_CONFIG_HEADER =
+  "# Managed by oh-my-harness — do not edit between markers\n" +
+  "# https://github.com/kyu1204/oh-my-harness\n";
+
+const CONFIG_MARKER_START = "# >>> oh-my-harness >>>";
+const CONFIG_MARKER_END = "# <<< oh-my-harness <<<";
+
+function normalizeMatcher(matcher: string): string {
+  if (!matcher) return matcher;
+  // Codex: apply_patch is the canonical edit tool; Claude uses Edit/Write aliases.
+  // Keep both so the same regex matcher works in either runtime.
+  if (/^Edit(\|Write)?$|^Write(\|Edit)?$/.test(matcher)) {
+    return `${matcher}|apply_patch`;
+  }
+  return matcher;
+}
+
+export interface CodexHooksFile {
+  hooks: Record<string, Array<{ matcher: string; hooks: Array<{ type: "command"; command: string }> }>>;
+}
+
+export function buildCodexHooks(hooksOutput: HooksOutput): {
+  codexHooks: CodexHooksFile;
+  skipped: string[];
+} {
+  const codexHooks: CodexHooksFile = { hooks: {} };
+  const skipped: string[] = [];
+
+  for (const [event, entries] of Object.entries(hooksOutput.hooksConfig)) {
+    if (!CODEX_SUPPORTED_EVENTS.has(event)) {
+      skipped.push(event);
+      continue;
+    }
+    codexHooks.hooks[event] = entries.map((entry) => ({
+      matcher: normalizeMatcher(entry.matcher),
+      hooks: entry.hooks.map((h) => ({ type: h.type, command: h.command })),
+    }));
+  }
+
+  return { codexHooks, skipped };
+}
+
+export function buildCodexConfigToml(existing: string): string {
+  const managedBlock =
+    `${CONFIG_MARKER_START}\n` +
+    `[features]\n` +
+    `codex_hooks = true\n` +
+    `${CONFIG_MARKER_END}\n`;
+
+  if (!existing) {
+    return CODEX_CONFIG_HEADER + managedBlock;
+  }
+
+  const re = new RegExp(`${CONFIG_MARKER_START}[\\s\\S]*?${CONFIG_MARKER_END}\\n?`);
+  if (re.test(existing)) {
+    return existing.replace(re, managedBlock);
+  }
+  const sep = existing.endsWith("\n") ? "" : "\n";
+  return existing + sep + managedBlock;
+}
+
+export async function generateCodexConfig(options: GenerateCodexConfigOptions): Promise<string[]> {
+  const { projectDir, hooksOutput } = options;
+  const codexDir = path.join(projectDir, ".codex");
+  await fs.mkdir(codexDir, { recursive: true });
+
+  const hooksPath = path.join(codexDir, "hooks.json");
+  const tomlPath = path.join(codexDir, "config.toml");
+
+  const { codexHooks } = buildCodexHooks(hooksOutput);
+  await fs.writeFile(hooksPath, JSON.stringify(codexHooks, null, 2) + "\n", "utf8");
+
+  let existingToml = "";
+  try {
+    existingToml = await fs.readFile(tomlPath, "utf8");
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code !== "ENOENT") throw error;
+  }
+  const newToml = buildCodexConfigToml(existingToml);
+  if (newToml !== existingToml) {
+    await fs.writeFile(tomlPath, newToml, "utf8");
+  }
+
+  return [hooksPath, tomlPath];
+}

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { parse, stringify } from "smol-toml";
 import type { HooksOutput } from "./hooks.js";
 
 export interface GenerateCodexConfigOptions {
@@ -17,11 +18,10 @@ const CODEX_SUPPORTED_EVENTS = new Set([
 ]);
 
 const CODEX_CONFIG_HEADER =
-  "# Managed by oh-my-harness — do not edit between markers\n" +
-  "# https://github.com/kyu1204/oh-my-harness\n";
-
-const CONFIG_MARKER_START = "# >>> oh-my-harness >>>";
-const CONFIG_MARKER_END = "# <<< oh-my-harness <<<";
+  "# Managed by oh-my-harness.\n" +
+  "# The codex_hooks=true entry under [features] is required.\n" +
+  "# Add your own tables (e.g. [mcp_servers.foo]) above or below freely.\n" +
+  "# https://github.com/kyu1204/oh-my-harness\n\n";
 
 function normalizeMatcher(matcher: string): string {
   if (!matcher) return matcher;
@@ -58,68 +58,40 @@ export function buildCodexHooks(hooksOutput: HooksOutput): {
   return { codexHooks, skipped };
 }
 
-const MARKER_RE = new RegExp(`${CONFIG_MARKER_START}[\\s\\S]*?${CONFIG_MARKER_END}\\n?`);
-const FEATURES_HEADER_RE = /^\[features\]\s*\n?/m;
-const NEXT_TABLE_RE = /^\[[^\]]+\]\s*$/m;
-const CODEX_HOOKS_LINE_RE = /^[ \t]*codex_hooks\s*=\s*(?:true|false)[ \t]*\n?/m;
-
-const INLINE_BLOCK =
-  `${CONFIG_MARKER_START}\n` +
-  `codex_hooks = true\n` +
-  `${CONFIG_MARKER_END}`;
-
-const STANDALONE_BLOCK =
-  `${CONFIG_MARKER_START}\n` +
-  `[features]\n` +
-  `codex_hooks = true\n` +
-  `${CONFIG_MARKER_END}\n`;
-
-function injectIntoExistingFeatures(toml: string): string {
-  const headerMatch = toml.match(FEATURES_HEADER_RE);
-  if (!headerMatch || headerMatch.index === undefined) return toml;
-
-  const headerStart = headerMatch.index;
-  const headerEnd = headerStart + headerMatch[0].length;
-
-  // Find next table header (or EOF) to bound the [features] body.
-  const rest = toml.slice(headerEnd);
-  const nextHeader = rest.match(NEXT_TABLE_RE);
-  const bodyLen = nextHeader && nextHeader.index !== undefined ? nextHeader.index : rest.length;
-  const body = rest.slice(0, bodyLen);
-  const after = rest.slice(bodyLen);
-
-  let newBody: string;
-  if (CODEX_HOOKS_LINE_RE.test(body)) {
-    // User already declared codex_hooks (with or without trailing keys).
-    // Replace that single line with our marker block to avoid duplicate keys.
-    newBody = body.replace(CODEX_HOOKS_LINE_RE, `${INLINE_BLOCK}\n`);
-  } else {
-    newBody = `${INLINE_BLOCK}\n${body}`;
-  }
-
-  return toml.slice(0, headerStart) + headerMatch[0] + newBody + after;
-}
-
+/**
+ * Build the .codex/config.toml content using a real TOML parser.
+ *
+ * Why a parser, not regex: the prior regex-based approach kept producing
+ * spec-edge bugs (duplicate [features] headers, duplicate codex_hooks keys,
+ * unhandled [[array-tables]], inline comments, multi-line strings). A
+ * spec-compliant parse → mutate → stringify round-trip handles all those
+ * cases for free.
+ *
+ * Trade-off: TOML round-trip does NOT preserve comments. Users who hand-edit
+ * .codex/config.toml will lose any comments on the next sync. The header
+ * banner above documents this and points users to keep their notes elsewhere
+ * (or in the project repo). MCP server entries, custom tables, and key
+ * values are all preserved.
+ */
 export function buildCodexConfigToml(existing: string): string {
-  // Step 1: strip any prior managed marker block so we can re-place it
-  // correctly without leaving stale duplicates behind.
-  const stripped = existing.replace(MARKER_RE, "").replace(/\n{3,}/g, "\n\n");
-
-  // Step 2: empty input → emit a standalone block with our own [features].
-  if (!stripped.trim()) {
-    return CODEX_CONFIG_HEADER + STANDALONE_BLOCK;
+  let data: Record<string, unknown> = {};
+  if (existing.trim()) {
+    try {
+      data = parse(existing) as Record<string, unknown>;
+    } catch {
+      // Malformed user TOML: start fresh. We don't write back if the result
+      // matches `existing` (see generateCodexConfig), so an unrelated parse
+      // error doesn't silently destroy data — only an actual edit triggers
+      // a write, and at that point `existing` is broken anyway.
+      data = {};
+    }
   }
 
-  // Step 3: user already declared [features] elsewhere in the file. We must
-  // NOT add a second [features] header (TOML v1.0 forbids redefining tables)
-  // and we must NOT introduce a duplicate codex_hooks key (also invalid).
-  if (FEATURES_HEADER_RE.test(stripped)) {
-    return injectIntoExistingFeatures(stripped);
-  }
+  const features = (data.features as Record<string, unknown> | undefined) ?? {};
+  features.codex_hooks = true;
+  data.features = features;
 
-  // Step 4: user content but no [features] yet → append our standalone block.
-  const sep = stripped.endsWith("\n") ? "" : "\n";
-  return stripped + sep + STANDALONE_BLOCK;
+  return CODEX_CONFIG_HEADER + stringify(data) + "\n";
 }
 
 export async function generateCodexConfig(options: GenerateCodexConfigOptions): Promise<string[]> {

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -59,7 +59,9 @@ export function buildCodexHooks(hooksOutput: HooksOutput): {
 }
 
 const MARKER_RE = new RegExp(`${CONFIG_MARKER_START}[\\s\\S]*?${CONFIG_MARKER_END}\\n?`);
-const FEATURES_HEADER_RE = /^\[features\]\s*$/m;
+const FEATURES_HEADER_RE = /^\[features\]\s*\n?/m;
+const NEXT_TABLE_RE = /^\[[^\]]+\]\s*$/m;
+const CODEX_HOOKS_LINE_RE = /^[ \t]*codex_hooks\s*=\s*(?:true|false)[ \t]*\n?/m;
 
 const INLINE_BLOCK =
   `${CONFIG_MARKER_START}\n` +
@@ -72,6 +74,32 @@ const STANDALONE_BLOCK =
   `codex_hooks = true\n` +
   `${CONFIG_MARKER_END}\n`;
 
+function injectIntoExistingFeatures(toml: string): string {
+  const headerMatch = toml.match(FEATURES_HEADER_RE);
+  if (!headerMatch || headerMatch.index === undefined) return toml;
+
+  const headerStart = headerMatch.index;
+  const headerEnd = headerStart + headerMatch[0].length;
+
+  // Find next table header (or EOF) to bound the [features] body.
+  const rest = toml.slice(headerEnd);
+  const nextHeader = rest.match(NEXT_TABLE_RE);
+  const bodyLen = nextHeader && nextHeader.index !== undefined ? nextHeader.index : rest.length;
+  const body = rest.slice(0, bodyLen);
+  const after = rest.slice(bodyLen);
+
+  let newBody: string;
+  if (CODEX_HOOKS_LINE_RE.test(body)) {
+    // User already declared codex_hooks (with or without trailing keys).
+    // Replace that single line with our marker block to avoid duplicate keys.
+    newBody = body.replace(CODEX_HOOKS_LINE_RE, `${INLINE_BLOCK}\n`);
+  } else {
+    newBody = `${INLINE_BLOCK}\n${body}`;
+  }
+
+  return toml.slice(0, headerStart) + headerMatch[0] + newBody + after;
+}
+
 export function buildCodexConfigToml(existing: string): string {
   // Step 1: strip any prior managed marker block so we can re-place it
   // correctly without leaving stale duplicates behind.
@@ -83,13 +111,10 @@ export function buildCodexConfigToml(existing: string): string {
   }
 
   // Step 3: user already declared [features] elsewhere in the file. We must
-  // NOT add a second [features] header (TOML v1.0 forbids redefining tables).
-  // Inject our key inside the existing table.
+  // NOT add a second [features] header (TOML v1.0 forbids redefining tables)
+  // and we must NOT introduce a duplicate codex_hooks key (also invalid).
   if (FEATURES_HEADER_RE.test(stripped)) {
-    return stripped.replace(
-      FEATURES_HEADER_RE,
-      (match) => `${match}\n${INLINE_BLOCK}`,
-    );
+    return injectIntoExistingFeatures(stripped);
   }
 
   // Step 4: user content but no [features] yet → append our standalone block.

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -79,14 +79,15 @@ export function buildCodexConfigToml(existing: string): string {
     try {
       data = parse(existing) as Record<string, unknown>;
     } catch (err) {
-      // Malformed user TOML: warn so the user knows we're regenerating, then
-      // start fresh. (generateCodexConfig still skips the write when the new
-      // content equals `existing`, so this only kicks in for actual edits.)
-      console.warn(
-        `oh-my-harness: .codex/config.toml is invalid TOML, regenerating ` +
-          `from scratch — original content will be replaced. (${(err as Error).message})`,
+      // Refuse to silently overwrite: a parse failure here means the user
+      // has hand-edited config.toml and introduced a syntax error. If we
+      // regenerate from {} we'd discard their MCP server entries and any
+      // other user tables. Surface the error and let the user fix it.
+      throw new Error(
+        `oh-my-harness: .codex/config.toml is invalid TOML; ` +
+          `fix the syntax error before re-running sync to avoid losing user content. ` +
+          `(${(err as Error).message})`,
       );
-      data = {};
     }
   }
 

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -21,24 +21,44 @@ _OMH_HOOK_NAME="$(basename "$0")"
 _OMH_EVENT="${event}"
 _OMH_LOGGED=0
 _log_event() {
+  # Build the JSONL record entirely through jq so every string field is
+  # JSON-escaped (quotes, backslashes, newlines, unicode). The previous
+  # printf+%s approach corrupted the line whenever reason or any other
+  # field contained these characters, and event-logger.ts silently drops
+  # unparseable lines, causing event loss.
   _OMH_LOGGED=1
   local decision="\${1:-allow}" reason="\${2:-}" meta="\${3:-}"
-  # The third arg, if provided, MUST be a serialized JSON value. Validate
-  # with jq to prevent a malformed caller from corrupting events.jsonl
-  # (event-logger.ts silently drops unparseable lines, which would cause
-  # event loss). On invalid input, fall back to logging without meta.
+  local ts
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # Meta must be a serialized JSON value (object/array/scalar); fall back
+  # to no-meta when invalid so a buggy caller can't drop the event entirely.
   if [ -n "$meta" ] && ! echo "$meta" | jq -e . >/dev/null 2>&1; then
     meta=""
   fi
   if [ -n "$meta" ]; then
-    printf '{"ts":"%s","event":"%s","hook":"%s","decision":"%s","reason":"%s","meta":%s}\\n' \\
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" "$meta" \\
+    jq -cn \\
+      --arg ts "$ts" --arg event "$_OMH_EVENT" --arg hook "$_OMH_HOOK_NAME" \\
+      --arg decision "$decision" --arg reason "$reason" --argjson meta "$meta" \\
+      '{ts:$ts,event:$event,hook:$hook,decision:$decision,reason:$reason,meta:$meta}' \\
       >> "$_OMH_STATE_DIR/${OMH_EVENTS_FILE}"
   else
-    printf '{"ts":"%s","event":"%s","hook":"%s","decision":"%s","reason":"%s"}\\n' \\
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" \\
+    jq -cn \\
+      --arg ts "$ts" --arg event "$_OMH_EVENT" --arg hook "$_OMH_HOOK_NAME" \\
+      --arg decision "$decision" --arg reason "$reason" \\
+      '{ts:$ts,event:$event,hook:$hook,decision:$decision,reason:$reason}' \\
       >> "$_OMH_STATE_DIR/${OMH_EVENTS_FILE}"
   fi
+}
+
+# Emit a Claude/Codex hook decision JSON to stdout with all fields safely
+# escaped. Catalog blocks should call this rather than handcrafting JSON
+# via echo "{...}" — a file name or pattern containing a quote, backslash,
+# or newline would otherwise produce invalid JSON that the runtime cannot
+# parse as a block decision.
+_emit_decision() {
+  local decision="\${1:-block}" reason="\${2:-}"
+  jq -cn --arg decision "$decision" --arg reason "$reason" \\
+    '{decision:$decision,reason:$reason}'
 }
 trap '_OMH_EXIT_CODE=$?; if [ "$_OMH_LOGGED" -eq 0 ]; then if [ "$_OMH_EXIT_CODE" -ne 0 ]; then _log_event "error" "hook exited with code $_OMH_EXIT_CODE"; else _log_event "allow"; fi; fi' EXIT
 # --- end logger ---`;

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -16,6 +16,13 @@ _OMH_LOGGED=0
 _log_event() {
   _OMH_LOGGED=1
   local decision="\${1:-allow}" reason="\${2:-}" meta="\${3:-}"
+  # The third arg, if provided, MUST be a serialized JSON value. Validate
+  # with jq to prevent a malformed caller from corrupting events.jsonl
+  # (event-logger.ts silently drops unparseable lines, which would cause
+  # event loss). On invalid input, fall back to logging without meta.
+  if [ -n "$meta" ] && ! echo "$meta" | jq -e . >/dev/null 2>&1; then
+    meta=""
+  fi
   if [ -n "$meta" ]; then
     printf '{"ts":"%s","event":"%s","hook":"%s","decision":"%s","reason":"%s","meta":%s}\\n' \\
       "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" "$meta" \\

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -1,11 +1,12 @@
 import { mkdir, writeFile, chmod, readFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
+import { OMH_HOOKS_DIR, OMH_STATE_DIR, OMH_MANIFEST, OMH_EVENTS_FILE } from "../utils/paths.js";
 
 function buildLoggerSnippet(event: string, projectDir?: string): string {
   const stateDir = projectDir
-    ? `${projectDir}/.claude/hooks/.state`
-    : ".claude/hooks/.state";
+    ? `${projectDir}/${OMH_STATE_DIR}`
+    : OMH_STATE_DIR;
   return `# --- oh-my-harness event logger ---
 _OMH_STATE_DIR="${stateDir}"
 mkdir -p "$_OMH_STATE_DIR" 2>/dev/null || true
@@ -14,10 +15,16 @@ _OMH_EVENT="${event}"
 _OMH_LOGGED=0
 _log_event() {
   _OMH_LOGGED=1
-  local decision="\${1:-allow}" reason="\${2:-}"
-  printf '{"ts":"%s","event":"%s","hook":"%s","decision":"%s","reason":"%s"}\\n' \\
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" \\
-    >> "$_OMH_STATE_DIR/events.jsonl"
+  local decision="\${1:-allow}" reason="\${2:-}" meta="\${3:-}"
+  if [ -n "$meta" ]; then
+    printf '{"ts":"%s","event":"%s","hook":"%s","decision":"%s","reason":"%s","meta":%s}\\n' \\
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" "$meta" \\
+      >> "$_OMH_STATE_DIR/${OMH_EVENTS_FILE}"
+  else
+    printf '{"ts":"%s","event":"%s","hook":"%s","decision":"%s","reason":"%s"}\\n' \\
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_OMH_EVENT" "$_OMH_HOOK_NAME" "$decision" "$reason" \\
+      >> "$_OMH_STATE_DIR/${OMH_EVENTS_FILE}"
+  fi
 }
 trap '_OMH_EXIT_CODE=$?; if [ "$_OMH_LOGGED" -eq 0 ]; then if [ "$_OMH_EXIT_CODE" -ne 0 ]; then _log_event "error" "hook exited with code $_OMH_EXIT_CODE"; else _log_event "allow"; fi; fi' EXIT
 # --- end logger ---`;
@@ -96,7 +103,7 @@ async function writeHookManifest(manifestPath: string, hooks: string[]): Promise
 
 export async function generateHooks(options: GenerateHooksOptions): Promise<HooksOutput> {
   const { projectDir, config } = options;
-  const hooksDir = join(projectDir, ".claude/hooks");
+  const hooksDir = join(projectDir, OMH_HOOKS_DIR);
 
   const eventMap: Array<[string, typeof config.hooks.preToolUse]> = [
     ["PreToolUse", config.hooks.preToolUse],
@@ -114,7 +121,8 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
   await mkdir(hooksDir, { recursive: true });
 
   // Read previous manifest to clean up stale hook files
-  const manifestPath = join(hooksDir, "oh-my-harness-manifest.json");
+  const manifestPath = join(projectDir, OMH_MANIFEST);
+  await mkdir(join(projectDir, OMH_STATE_DIR), { recursive: true });
   const previousHooks = await readPreviousHookNames(manifestPath);
 
   if (allHooks.length === 0) {

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -1,14 +1,21 @@
 import { mkdir, writeFile, chmod, readFile, unlink } from "node:fs/promises";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import type { MergedConfig } from "../core/preset-types.js";
 import { OMH_HOOKS_DIR, OMH_STATE_DIR, OMH_MANIFEST, OMH_EVENTS_FILE } from "../utils/paths.js";
+
+// Wrap a path/value in bash single quotes, escaping any embedded single
+// quotes. Single-quoted strings are not subject to shell expansion, so this
+// is safe for paths containing $, backticks, double quotes, etc.
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 function buildLoggerSnippet(event: string, projectDir?: string): string {
   const stateDir = projectDir
     ? `${projectDir}/${OMH_STATE_DIR}`
     : OMH_STATE_DIR;
   return `# --- oh-my-harness event logger ---
-_OMH_STATE_DIR="${stateDir}"
+_OMH_STATE_DIR=${shellSingleQuote(stateDir)}
 mkdir -p "$_OMH_STATE_DIR" 2>/dev/null || true
 _OMH_HOOK_NAME="$(basename "$0")"
 _OMH_EVENT="${event}"
@@ -80,8 +87,15 @@ function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
 async function readPreviousHookNames(manifestPath: string): Promise<string[]> {
   try {
     const manifestRaw = await readFile(manifestPath, "utf8");
-    const manifest = JSON.parse(manifestRaw) as { hooks?: string[] };
-    return manifest.hooks ?? [];
+    const manifest = JSON.parse(manifestRaw) as { hooks?: unknown };
+    if (!Array.isArray(manifest.hooks)) return [];
+    // The manifest is on-disk input — a malicious or hand-edited entry like
+    // "../../etc/hosts" would otherwise become an unlink target. Allow only
+    // bare basenames to defend against path traversal during cleanup.
+    return manifest.hooks.filter(
+      (name): name is string =>
+        typeof name === "string" && name.length > 0 && basename(name) === name,
+    );
   } catch (err) {
     if (isErrnoException(err) && err.code === "ENOENT") {
       return [];
@@ -178,7 +192,7 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
     if (!hooksConfig[p.event]) hooksConfig[p.event] = [];
     hooksConfig[p.event].push({
       matcher: p.matcher,
-      hooks: [{ type: "command", command: `bash "${p.scriptPath}"` }],
+      hooks: [{ type: "command", command: `bash ${shellSingleQuote(p.scriptPath)}` }],
     });
   }
 

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -134,41 +134,45 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
     return { hooksConfig: {}, generatedFiles: [] };
   }
 
-  const generatedFiles: string[] = [];
-  const hooksConfig: Record<string, Array<{ matcher: string; hooks: HookCommand[] }>> = {};
   const usedScriptNames = new Set<string>();
+  const planned: Array<{ event: string; matcher: string; scriptPath: string; wrappedScript: string }> = [];
 
   for (const hook of allHooks) {
-    if (!hook.inline) {
-      continue;
-    }
+    if (!hook.inline) continue;
 
     const safeId = hook.id.replace(/[^a-zA-Z0-9_-]/g, "") || "hook";
     let scriptName = `${safeId}.sh`;
-    // Prevent collisions within the same event using numeric suffix
     if (usedScriptNames.has(scriptName)) {
       let counter = 1;
-      while (usedScriptNames.has(`${safeId}-${counter}.sh`)) {
-        counter++;
-      }
+      while (usedScriptNames.has(`${safeId}-${counter}.sh`)) counter++;
       scriptName = `${safeId}-${counter}.sh`;
     }
     usedScriptNames.add(scriptName);
 
-    const scriptPath = join(hooksDir, scriptName);
-    const wrappedScript = wrapWithLogger(hook.inline, hook.event, projectDir);
-    await writeFile(scriptPath, wrappedScript, "utf8");
-    await chmod(scriptPath, 0o755);
-    generatedFiles.push(scriptPath);
-
-    const entry = {
+    planned.push({
+      event: hook.event,
       matcher: hook.matcher,
-      hooks: [{ type: "command" as const, command: `bash "${scriptPath}"` }],
-    };
-    if (!hooksConfig[hook.event]) {
-      hooksConfig[hook.event] = [];
-    }
-    hooksConfig[hook.event].push(entry);
+      scriptPath: join(hooksDir, scriptName),
+      wrappedScript: wrapWithLogger(hook.inline, hook.event, projectDir),
+    });
+  }
+
+  // Independent IO across hooks — parallelize.
+  await Promise.all(
+    planned.map(async (p) => {
+      await writeFile(p.scriptPath, p.wrappedScript, "utf8");
+      await chmod(p.scriptPath, 0o755);
+    }),
+  );
+
+  const generatedFiles = planned.map((p) => p.scriptPath);
+  const hooksConfig: Record<string, Array<{ matcher: string; hooks: HookCommand[] }>> = {};
+  for (const p of planned) {
+    if (!hooksConfig[p.event]) hooksConfig[p.event] = [];
+    hooksConfig[p.event].push({
+      matcher: p.matcher,
+      hooks: [{ type: "command", command: `bash "${p.scriptPath}"` }],
+    });
   }
 
   // Remove stale hook files from previous sync that are no longer generated

--- a/src/generators/managed-md.ts
+++ b/src/generators/managed-md.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs/promises";
+import type { ClaudeMdSection } from "../core/preset-types.js";
+import { extractManagedSections, removeManagedSection, upsertManagedSection } from "../utils/markdown.js";
+import { readFileOrDefault } from "../utils/fs-helpers.js";
+
+export async function writeManagedMarkdown(
+  filePath: string,
+  sections: ClaudeMdSection[],
+): Promise<string> {
+  let content = await readFileOrDefault(filePath, "");
+
+  // Strip ALL managed sections (including those still in config) so the
+  // re-insertion below honors the new priority order. upsertManagedSection
+  // does in-place replace when the marker exists, which would otherwise
+  // freeze the original ordering.
+  for (const { id } of extractManagedSections(content)) {
+    content = removeManagedSection(content, id);
+  }
+  // Normalize whitespace so repeated stripping doesn't accumulate blank lines.
+  content = content.replace(/^\n+/, "").replace(/\n+$/, "");
+  if (content) content += "\n";
+
+  const sorted = [...sections].sort((a, b) => (a.priority ?? 50) - (b.priority ?? 50));
+  for (const section of sorted) {
+    content = upsertManagedSection(content, section.id, section.content ?? "");
+  }
+
+  await fs.writeFile(filePath, content, "utf8");
+  return content;
+}

--- a/src/utils/fs-helpers.ts
+++ b/src/utils/fs-helpers.ts
@@ -4,8 +4,11 @@ export async function pathExists(p: string): Promise<boolean> {
   try {
     await fs.access(p);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    // Permission/IO errors must NOT masquerade as "missing" — that would
+    // silently skip migration steps for files that actually exist.
+    throw err;
   }
 }
 

--- a/src/utils/fs-helpers.ts
+++ b/src/utils/fs-helpers.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs/promises";
+
+export async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readFileOrDefault(filePath: string, fallback = ""): Promise<string> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return fallback;
+    throw err;
+  }
+}
+
+export async function endsWithNewline(filePath: string): Promise<boolean> {
+  const fh = await fs.open(filePath, "r");
+  try {
+    const { size } = await fh.stat();
+    if (size === 0) return true;
+    const buf = Buffer.alloc(1);
+    await fh.read(buf, 0, 1, size - 1);
+    return buf[0] === 0x0a;
+  } finally {
+    await fh.close();
+  }
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,12 @@
+export const OMH_DIR = ".omh";
+export const OMH_HOOKS_DIR = `${OMH_DIR}/hooks`;
+export const OMH_STATE_DIR = `${OMH_DIR}/state`;
+export const OMH_MANIFEST = `${OMH_DIR}/manifest.json`;
+export const OMH_EVENTS_FILE = "events.jsonl";
+export const OMH_TDD_STATE_FILE = "tdd-edits.json";
+
+export const LEGACY_STATE_DIR = ".claude/hooks/.state";
+export const LEGACY_HOOKS_DIR = ".claude/hooks";
+export const LEGACY_MANIFEST = ".claude/hooks/oh-my-harness-manifest.json";
+export const LEGACY_TDD_FILE = "edit-history.json";
+export const LEGACY_CONFIG_AUDIT_LOG = "config-audit.log";

--- a/src/utils/state-migration.ts
+++ b/src/utils/state-migration.ts
@@ -23,16 +23,21 @@ interface ParsedConfigAudit {
 function configAuditToEvent(line: string): string | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
-  let parsed: ParsedConfigAudit;
+  let parsed: unknown;
   try {
-    parsed = JSON.parse(trimmed) as ParsedConfigAudit;
+    parsed = JSON.parse(trimmed);
   } catch {
     return null;
   }
-  if (!parsed.ts) return null;
-  const meta = { source: parsed.source ?? "unknown", file: parsed.file ?? "unknown" };
+  // Valid JSON like `null`, `42`, `["x"]` parses successfully but is not an
+  // audit record — skip silently so a single malformed line can't abort the
+  // entire .map().filter() chain in the caller.
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const audit = parsed as ParsedConfigAudit;
+  if (!audit.ts) return null;
+  const meta = { source: audit.source ?? "unknown", file: audit.file ?? "unknown" };
   return JSON.stringify({
-    ts: parsed.ts,
+    ts: audit.ts,
     event: "ConfigChange",
     hook: "catalog-config-audit.sh",
     decision: "allow",

--- a/src/utils/state-migration.ts
+++ b/src/utils/state-migration.ts
@@ -56,6 +56,9 @@ export interface MigrationReport {
 
 export async function migrateLegacyState(projectDir: string): Promise<MigrationReport> {
   const report: MigrationReport = { migrated: [], skipped: [] };
+  // Only files we actually consumed/copied get unlinked. Files skipped because
+  // a destination already exists are preserved so the user can recover them.
+  const cleanupTargets = new Set<string>();
 
   const legacyState = path.join(projectDir, LEGACY_STATE_DIR);
   const newState = path.join(projectDir, OMH_STATE_DIR);
@@ -70,17 +73,27 @@ export async function migrateLegacyState(projectDir: string): Promise<MigrationR
   // events.jsonl — copy if new doesn't exist
   const legacyEvents = path.join(legacyState, OMH_EVENTS_FILE);
   const newEvents = path.join(newState, OMH_EVENTS_FILE);
-  if ((await pathExists(legacyEvents)) && !(await pathExists(newEvents))) {
-    await fs.copyFile(legacyEvents, newEvents);
-    report.migrated.push("events.jsonl");
+  if (await pathExists(legacyEvents)) {
+    if (!(await pathExists(newEvents))) {
+      await fs.copyFile(legacyEvents, newEvents);
+      report.migrated.push("events.jsonl");
+      cleanupTargets.add(legacyEvents);
+    } else {
+      report.skipped.push("events.jsonl (destination exists)");
+    }
   }
 
   // edit-history.json → tdd-edits.json
   const legacyTdd = path.join(legacyState, LEGACY_TDD_FILE);
   const newTdd = path.join(newState, OMH_TDD_STATE_FILE);
-  if ((await pathExists(legacyTdd)) && !(await pathExists(newTdd))) {
-    await fs.copyFile(legacyTdd, newTdd);
-    report.migrated.push(`${LEGACY_TDD_FILE} → ${OMH_TDD_STATE_FILE}`);
+  if (await pathExists(legacyTdd)) {
+    if (!(await pathExists(newTdd))) {
+      await fs.copyFile(legacyTdd, newTdd);
+      report.migrated.push(`${LEGACY_TDD_FILE} → ${OMH_TDD_STATE_FILE}`);
+      cleanupTargets.add(legacyTdd);
+    } else {
+      report.skipped.push(`${LEGACY_TDD_FILE} (destination exists)`);
+    }
   }
 
   // config-audit.log → append into events.jsonl as ConfigChange entries
@@ -91,21 +104,27 @@ export async function migrateLegacyState(projectDir: string): Promise<MigrationR
     if (lines.length > 0) {
       await fs.appendFile(newEvents, lines.join("\n") + "\n", "utf8");
       report.migrated.push(`${LEGACY_CONFIG_AUDIT_LOG} → events.jsonl (${lines.length} entries)`);
+      cleanupTargets.add(legacyAuditLog);
+    } else {
+      report.skipped.push(`${LEGACY_CONFIG_AUDIT_LOG} (no valid lines)`);
     }
   }
 
   // manifest
   const legacyManifest = path.join(projectDir, LEGACY_MANIFEST);
   const newManifest = path.join(projectDir, OMH_MANIFEST);
-  if ((await pathExists(legacyManifest)) && !(await pathExists(newManifest))) {
-    await fs.copyFile(legacyManifest, newManifest);
-    report.migrated.push("manifest.json");
+  if (await pathExists(legacyManifest)) {
+    if (!(await pathExists(newManifest))) {
+      await fs.copyFile(legacyManifest, newManifest);
+      report.migrated.push("manifest.json");
+      cleanupTargets.add(legacyManifest);
+    } else {
+      report.skipped.push("manifest.json (destination exists)");
+    }
   }
 
-  // Best-effort cleanup of the legacy state directory contents we've copied.
-  // Leave the rest (e.g. user-added artifacts) alone.
-  for (const name of [OMH_EVENTS_FILE, LEGACY_TDD_FILE, LEGACY_CONFIG_AUDIT_LOG]) {
-    const p = path.join(legacyState, name);
+  // Cleanup only files we actually migrated.
+  for (const p of cleanupTargets) {
     try {
       await fs.unlink(p);
     } catch {

--- a/src/utils/state-migration.ts
+++ b/src/utils/state-migration.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  OMH_DIR,
+  OMH_STATE_DIR,
+  OMH_MANIFEST,
+  OMH_EVENTS_FILE,
+  OMH_TDD_STATE_FILE,
+  LEGACY_STATE_DIR,
+  LEGACY_HOOKS_DIR,
+  LEGACY_MANIFEST,
+  LEGACY_TDD_FILE,
+  LEGACY_CONFIG_AUDIT_LOG,
+} from "./paths.js";
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface ParsedConfigAudit {
+  ts?: string;
+  source?: string;
+  file?: string;
+}
+
+function configAuditToEvent(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  let parsed: ParsedConfigAudit;
+  try {
+    parsed = JSON.parse(trimmed) as ParsedConfigAudit;
+  } catch {
+    return null;
+  }
+  if (!parsed.ts) return null;
+  const meta = { source: parsed.source ?? "unknown", file: parsed.file ?? "unknown" };
+  return JSON.stringify({
+    ts: parsed.ts,
+    event: "ConfigChange",
+    hook: "catalog-config-audit.sh",
+    decision: "allow",
+    reason: "",
+    meta,
+  });
+}
+
+export interface MigrationReport {
+  migrated: string[];
+  skipped: string[];
+}
+
+export async function migrateLegacyState(projectDir: string): Promise<MigrationReport> {
+  const report: MigrationReport = { migrated: [], skipped: [] };
+
+  const legacyState = path.join(projectDir, LEGACY_STATE_DIR);
+  const newState = path.join(projectDir, OMH_STATE_DIR);
+
+  if (!(await pathExists(legacyState))) {
+    return report;
+  }
+
+  await fs.mkdir(path.join(projectDir, OMH_DIR), { recursive: true });
+  await fs.mkdir(newState, { recursive: true });
+
+  // events.jsonl — copy if new doesn't exist
+  const legacyEvents = path.join(legacyState, OMH_EVENTS_FILE);
+  const newEvents = path.join(newState, OMH_EVENTS_FILE);
+  if ((await pathExists(legacyEvents)) && !(await pathExists(newEvents))) {
+    await fs.copyFile(legacyEvents, newEvents);
+    report.migrated.push("events.jsonl");
+  }
+
+  // edit-history.json → tdd-edits.json
+  const legacyTdd = path.join(legacyState, LEGACY_TDD_FILE);
+  const newTdd = path.join(newState, OMH_TDD_STATE_FILE);
+  if ((await pathExists(legacyTdd)) && !(await pathExists(newTdd))) {
+    await fs.copyFile(legacyTdd, newTdd);
+    report.migrated.push(`${LEGACY_TDD_FILE} → ${OMH_TDD_STATE_FILE}`);
+  }
+
+  // config-audit.log → append into events.jsonl as ConfigChange entries
+  const legacyAuditLog = path.join(legacyState, LEGACY_CONFIG_AUDIT_LOG);
+  if (await pathExists(legacyAuditLog)) {
+    const raw = await fs.readFile(legacyAuditLog, "utf8");
+    const lines = raw.split("\n").map(configAuditToEvent).filter((l): l is string => l !== null);
+    if (lines.length > 0) {
+      await fs.appendFile(newEvents, lines.join("\n") + "\n", "utf8");
+      report.migrated.push(`${LEGACY_CONFIG_AUDIT_LOG} → events.jsonl (${lines.length} entries)`);
+    }
+  }
+
+  // manifest
+  const legacyManifest = path.join(projectDir, LEGACY_MANIFEST);
+  const newManifest = path.join(projectDir, OMH_MANIFEST);
+  if ((await pathExists(legacyManifest)) && !(await pathExists(newManifest))) {
+    await fs.copyFile(legacyManifest, newManifest);
+    report.migrated.push("manifest.json");
+  }
+
+  // Best-effort cleanup of the legacy state directory contents we've copied.
+  // Leave the rest (e.g. user-added artifacts) alone.
+  for (const name of [OMH_EVENTS_FILE, LEGACY_TDD_FILE, LEGACY_CONFIG_AUDIT_LOG]) {
+    const p = path.join(legacyState, name);
+    try {
+      await fs.unlink(p);
+    } catch {
+      // ignore
+    }
+  }
+  // Try to remove now-empty .claude/hooks/.state and parent .claude/hooks if empty
+  for (const dir of [legacyState, path.join(projectDir, LEGACY_HOOKS_DIR)]) {
+    try {
+      await fs.rmdir(dir);
+    } catch {
+      // not empty or missing — fine
+    }
+  }
+
+  return report;
+}

--- a/src/utils/state-migration.ts
+++ b/src/utils/state-migration.ts
@@ -12,15 +12,7 @@ import {
   LEGACY_TDD_FILE,
   LEGACY_CONFIG_AUDIT_LOG,
 } from "./paths.js";
-
-async function pathExists(p: string): Promise<boolean> {
-  try {
-    await fs.access(p);
-    return true;
-  } catch {
-    return false;
-  }
-}
+import { pathExists, endsWithNewline } from "./fs-helpers.js";
 
 interface ParsedConfigAudit {
   ts?: string;
@@ -114,13 +106,9 @@ export async function migrateLegacyState(projectDir: string): Promise<MigrationR
         // exists but its last byte isn't \n (truncation, manual edit), the
         // first absorbed entry would otherwise glue onto the last record
         // and break parsing for the whole file.
-        let prefix = "";
-        if (await pathExists(newEvents)) {
-          const existing = await fs.readFile(newEvents, "utf8");
-          if (existing.length > 0 && !existing.endsWith("\n")) {
-            prefix = "\n";
-          }
-        }
+        const prefix = (await pathExists(newEvents)) && !(await endsWithNewline(newEvents))
+          ? "\n"
+          : "";
         await fs.appendFile(newEvents, prefix + lines.join("\n") + "\n", "utf8");
         report.migrated.push(`${LEGACY_CONFIG_AUDIT_LOG} → events.jsonl (${lines.length} entries)`);
         cleanupTargets.add(legacyAuditLog);

--- a/src/utils/state-migration.ts
+++ b/src/utils/state-migration.ts
@@ -62,58 +62,77 @@ export async function migrateLegacyState(projectDir: string): Promise<MigrationR
 
   const legacyState = path.join(projectDir, LEGACY_STATE_DIR);
   const newState = path.join(projectDir, OMH_STATE_DIR);
+  const legacyManifest = path.join(projectDir, LEGACY_MANIFEST);
+  const newManifest = path.join(projectDir, OMH_MANIFEST);
 
-  if (!(await pathExists(legacyState))) {
+  const hasLegacyState = await pathExists(legacyState);
+  const hasLegacyManifest = await pathExists(legacyManifest);
+
+  // Nothing legacy to migrate.
+  if (!hasLegacyState && !hasLegacyManifest) {
     return report;
   }
 
   await fs.mkdir(path.join(projectDir, OMH_DIR), { recursive: true });
-  await fs.mkdir(newState, { recursive: true });
 
-  // events.jsonl — copy if new doesn't exist
-  const legacyEvents = path.join(legacyState, OMH_EVENTS_FILE);
-  const newEvents = path.join(newState, OMH_EVENTS_FILE);
-  if (await pathExists(legacyEvents)) {
-    if (!(await pathExists(newEvents))) {
-      await fs.copyFile(legacyEvents, newEvents);
-      report.migrated.push("events.jsonl");
-      cleanupTargets.add(legacyEvents);
-    } else {
-      report.skipped.push("events.jsonl (destination exists)");
+  if (hasLegacyState) {
+    await fs.mkdir(newState, { recursive: true });
+
+    // events.jsonl — copy if new doesn't exist
+    const legacyEvents = path.join(legacyState, OMH_EVENTS_FILE);
+    const newEvents = path.join(newState, OMH_EVENTS_FILE);
+    if (await pathExists(legacyEvents)) {
+      if (!(await pathExists(newEvents))) {
+        await fs.copyFile(legacyEvents, newEvents);
+        report.migrated.push("events.jsonl");
+        cleanupTargets.add(legacyEvents);
+      } else {
+        report.skipped.push("events.jsonl (destination exists)");
+      }
+    }
+
+    // edit-history.json → tdd-edits.json
+    const legacyTdd = path.join(legacyState, LEGACY_TDD_FILE);
+    const newTdd = path.join(newState, OMH_TDD_STATE_FILE);
+    if (await pathExists(legacyTdd)) {
+      if (!(await pathExists(newTdd))) {
+        await fs.copyFile(legacyTdd, newTdd);
+        report.migrated.push(`${LEGACY_TDD_FILE} → ${OMH_TDD_STATE_FILE}`);
+        cleanupTargets.add(legacyTdd);
+      } else {
+        report.skipped.push(`${LEGACY_TDD_FILE} (destination exists)`);
+      }
+    }
+
+    // config-audit.log → append into events.jsonl as ConfigChange entries
+    const legacyAuditLog = path.join(legacyState, LEGACY_CONFIG_AUDIT_LOG);
+    if (await pathExists(legacyAuditLog)) {
+      const raw = await fs.readFile(legacyAuditLog, "utf8");
+      const lines = raw.split("\n").map(configAuditToEvent).filter((l): l is string => l !== null);
+      if (lines.length > 0) {
+        // Guarantee a JSONL boundary newline before appending. If newEvents
+        // exists but its last byte isn't \n (truncation, manual edit), the
+        // first absorbed entry would otherwise glue onto the last record
+        // and break parsing for the whole file.
+        let prefix = "";
+        if (await pathExists(newEvents)) {
+          const existing = await fs.readFile(newEvents, "utf8");
+          if (existing.length > 0 && !existing.endsWith("\n")) {
+            prefix = "\n";
+          }
+        }
+        await fs.appendFile(newEvents, prefix + lines.join("\n") + "\n", "utf8");
+        report.migrated.push(`${LEGACY_CONFIG_AUDIT_LOG} → events.jsonl (${lines.length} entries)`);
+        cleanupTargets.add(legacyAuditLog);
+      } else {
+        report.skipped.push(`${LEGACY_CONFIG_AUDIT_LOG} (no valid lines)`);
+      }
     }
   }
 
-  // edit-history.json → tdd-edits.json
-  const legacyTdd = path.join(legacyState, LEGACY_TDD_FILE);
-  const newTdd = path.join(newState, OMH_TDD_STATE_FILE);
-  if (await pathExists(legacyTdd)) {
-    if (!(await pathExists(newTdd))) {
-      await fs.copyFile(legacyTdd, newTdd);
-      report.migrated.push(`${LEGACY_TDD_FILE} → ${OMH_TDD_STATE_FILE}`);
-      cleanupTargets.add(legacyTdd);
-    } else {
-      report.skipped.push(`${LEGACY_TDD_FILE} (destination exists)`);
-    }
-  }
-
-  // config-audit.log → append into events.jsonl as ConfigChange entries
-  const legacyAuditLog = path.join(legacyState, LEGACY_CONFIG_AUDIT_LOG);
-  if (await pathExists(legacyAuditLog)) {
-    const raw = await fs.readFile(legacyAuditLog, "utf8");
-    const lines = raw.split("\n").map(configAuditToEvent).filter((l): l is string => l !== null);
-    if (lines.length > 0) {
-      await fs.appendFile(newEvents, lines.join("\n") + "\n", "utf8");
-      report.migrated.push(`${LEGACY_CONFIG_AUDIT_LOG} → events.jsonl (${lines.length} entries)`);
-      cleanupTargets.add(legacyAuditLog);
-    } else {
-      report.skipped.push(`${LEGACY_CONFIG_AUDIT_LOG} (no valid lines)`);
-    }
-  }
-
-  // manifest
-  const legacyManifest = path.join(projectDir, LEGACY_MANIFEST);
-  const newManifest = path.join(projectDir, OMH_MANIFEST);
-  if (await pathExists(legacyManifest)) {
+  // Manifest migration runs whether or not the .state dir exists — a user
+  // who synced but never fired a hook still has manifest at the legacy path.
+  if (hasLegacyManifest) {
     if (!(await pathExists(newManifest))) {
       await fs.copyFile(legacyManifest, newManifest);
       report.migrated.push("manifest.json");

--- a/tests/integration/cli-add-remove.test.ts
+++ b/tests/integration/cli-add-remove.test.ts
@@ -92,7 +92,7 @@ describe("removeCommand", () => {
     await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
     await addCommand("nextjs", { projectDir: tmpDir, presetsDir: PRESETS_DIR });
 
-    const hooksDir = path.join(tmpDir, ".claude", "hooks");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
     const filesBefore = await fs.readdir(hooksDir);
     // nextjs adds its own hook scripts on top of _base hooks
     const nextjsHooksBefore = filesBefore.filter((f) => f.startsWith("nextjs-"));

--- a/tests/integration/cli-doctor.test.ts
+++ b/tests/integration/cli-doctor.test.ts
@@ -89,4 +89,38 @@ describe("doctorCommand", () => {
     expect(result.healthy).toBe(true);
     expect(result.exitCode).toBe(0);
   });
+
+  it("verifies AGENTS.md exists for Codex compatibility", async () => {
+    await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
+    const result = await doctorCommand({ projectDir: tmpDir });
+    expect(result.checks.agentsMd).toBe(true);
+  });
+
+  it("reports unhealthy when AGENTS.md is missing", async () => {
+    await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
+    await fs.rm(path.join(tmpDir, "AGENTS.md"));
+    const result = await doctorCommand({ projectDir: tmpDir });
+    expect(result.checks.agentsMd).toBe(false);
+    expect(result.healthy).toBe(false);
+  });
+
+  it("verifies .codex/hooks.json and config.toml exist for Codex emitter", async () => {
+    await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
+    const result = await doctorCommand({ projectDir: tmpDir });
+    expect(result.checks.codexConfig).toBe(true);
+  });
+
+  it("verifies hook scripts under .omh/hooks are executable", async () => {
+    await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
+    const result = await doctorCommand({ projectDir: tmpDir });
+    expect(result.checks.hooksExecutable).toBe(true);
+
+    // Drop X bit on one script and re-check
+    const hookFiles = await fs.readdir(path.join(tmpDir, ".omh/hooks"));
+    const sh = hookFiles.find((f) => f.endsWith(".sh"))!;
+    await fs.chmod(path.join(tmpDir, ".omh/hooks", sh), 0o644);
+
+    const after = await doctorCommand({ projectDir: tmpDir });
+    expect(after.checks.hooksExecutable).toBe(false);
+  });
 });

--- a/tests/integration/cli-doctor.test.ts
+++ b/tests/integration/cli-doctor.test.ts
@@ -110,6 +110,18 @@ describe("doctorCommand", () => {
     expect(result.checks.codexConfig).toBe(true);
   });
 
+  it("reports unhealthy when .codex/hooks.json is invalid JSON", async () => {
+    await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
+    // Simulate a merge conflict / hand-edit corrupting hooks.json
+    await fs.writeFile(path.join(tmpDir, ".codex", "hooks.json"), "<<< not json", "utf-8");
+
+    const result = await doctorCommand({ projectDir: tmpDir });
+
+    expect(result.checks.codexConfig).toBe(false);
+    expect(result.healthy).toBe(false);
+    expect(result.messages.some((m) => m.includes("hooks.json") || m.includes("invalid"))).toBe(true);
+  });
+
   it("verifies hook scripts under .omh/hooks are executable", async () => {
     await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
     const result = await doctorCommand({ projectDir: tmpDir });

--- a/tests/integration/cli-sync.test.ts
+++ b/tests/integration/cli-sync.test.ts
@@ -75,7 +75,7 @@ describe("syncCommand", () => {
 
     await syncCommand({ projectDir: tmpDir });
 
-    const hooksDir = path.join(tmpDir, ".claude", "hooks");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
     const files = await fs.readdir(hooksDir);
     expect(files.length).toBeGreaterThan(0);
     expect(files.some((f) => f.endsWith(".sh"))).toBe(true);
@@ -89,7 +89,7 @@ describe("syncCommand", () => {
 
     await syncCommand({ projectDir: tmpDir });
 
-    const hooksDir = path.join(tmpDir, ".claude", "hooks");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
     const files = await fs.readdir(hooksDir);
     const shFile = files.find((f) => f.endsWith(".sh"))!;
     const scriptContent = await fs.readFile(path.join(hooksDir, shFile), "utf-8");

--- a/tests/integration/error-paths.test.ts
+++ b/tests/integration/error-paths.test.ts
@@ -185,7 +185,7 @@ describe("generate() error paths", () => {
 
 describe("readEvents error paths", () => {
   it("returns empty array when events file contains completely corrupted binary-like data", async () => {
-    const stateDir = join(tmpDir, ".claude/hooks/.state");
+    const stateDir = join(tmpDir, ".omh/state");
     await mkdir(stateDir, { recursive: true });
     // Write non-JSON content that mimics corruption
     await writeFile(
@@ -198,7 +198,7 @@ describe("readEvents error paths", () => {
   });
 
   it("returns only valid events from a partially corrupted file", async () => {
-    const stateDir = join(tmpDir, ".claude/hooks/.state");
+    const stateDir = join(tmpDir, ".omh/state");
     await mkdir(stateDir, { recursive: true });
 
     const validEvent = JSON.stringify({
@@ -223,7 +223,7 @@ describe("readEvents error paths", () => {
   });
 
   it("throws when appendEvent target directory is read-only", async () => {
-    const stateDir = join(tmpDir, ".claude/hooks/.state");
+    const stateDir = join(tmpDir, ".omh/state");
     await mkdir(stateDir, { recursive: true });
     // Make the state directory read-only so appendFile fails
     await chmod(stateDir, 0o444);

--- a/tests/integration/generate-pipeline.test.ts
+++ b/tests/integration/generate-pipeline.test.ts
@@ -59,7 +59,7 @@ describe("generate() pipeline", () => {
 
     const result = await generate({ projectDir: tmpDir, config });
 
-    const scriptPath = join(tmpDir, ".claude/hooks/cmd-guard.sh");
+    const scriptPath = join(tmpDir, ".omh/hooks/cmd-guard.sh");
     const scriptStat = await stat(scriptPath);
     // Check executable bit (owner execute = 0o100)
     expect(scriptStat.mode & 0o111).toBeGreaterThan(0);
@@ -114,7 +114,7 @@ describe("generate() pipeline", () => {
     expect(occurrences).toBe(1);
   });
 
-  it("adds .claude/hooks/.state/ to .gitignore when hooks are present", async () => {
+  it("adds .omh/state/ to .gitignore when hooks are present", async () => {
     const config: MergedConfig = {
       presets: ["test-preset"],
       variables: {},
@@ -135,6 +135,6 @@ describe("generate() pipeline", () => {
     await generate({ projectDir: tmpDir, config });
 
     const gitignore = await readFile(join(tmpDir, ".gitignore"), "utf-8");
-    expect(gitignore).toContain(".claude/hooks/.state/");
+    expect(gitignore).toContain(".omh/state/");
   });
 });

--- a/tests/integration/hook-logging.test.ts
+++ b/tests/integration/hook-logging.test.ts
@@ -102,7 +102,7 @@ exit 0`;
     runHookScript(scriptPath, '{"tool_name":"Bash"}');
 
     // Verify raw JSONL is valid and has all required fields
-    const eventsFile = join(tmpDir, ".claude/hooks/.state/events.jsonl");
+    const eventsFile = join(tmpDir, ".omh/state/events.jsonl");
     const raw = await readFile(eventsFile, "utf-8");
     const parsed = JSON.parse(raw.trim());
 

--- a/tests/integration/init-command.test.ts
+++ b/tests/integration/init-command.test.ts
@@ -71,18 +71,18 @@ describe("initCommand", () => {
   it("generates hook scripts", async () => {
     await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
 
-    const hooksDir = path.join(tmpDir, ".claude", "hooks");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
     const files = await fs.readdir(hooksDir);
     expect(files.length).toBeGreaterThan(0);
     // base preset has base-command-guard and base-test-before-commit hooks
     expect(files).toContain("base-command-guard.sh");
   });
 
-  it("updates .gitignore with .claude/hooks/ entry", async () => {
+  it("updates .gitignore with .omh/state/ entry", async () => {
     await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
 
     const gitignore = await fs.readFile(path.join(tmpDir, ".gitignore"), "utf-8");
-    expect(gitignore).toContain(".claude/hooks/");
+    expect(gitignore).toContain(".omh/state/");
   });
 
   it("--preset flag uses existing preset flow", async () => {

--- a/tests/integration/multi-block-execution.test.ts
+++ b/tests/integration/multi-block-execution.test.ts
@@ -416,7 +416,7 @@ describe("hooksConfig structure validation", () => {
         // Each hook has type: "command" and command string
         expect(hook.type).toBe("command");
         expect(typeof hook.command).toBe("string");
-        expect(hook.command).toMatch(/\.sh"?$/);
+        expect(hook.command).toMatch(/\.sh["']?$/);
       }
     }
   });

--- a/tests/integration/multi-block-execution.test.ts
+++ b/tests/integration/multi-block-execution.test.ts
@@ -240,7 +240,7 @@ describe("PreToolUse + PostToolUse mix", () => {
 
     await generateHooks({ projectDir: tmpDir, config });
 
-    const hooksDir = join(tmpDir, ".claude/hooks");
+    const hooksDir = join(tmpDir, ".omh/hooks");
     const preScript = await readFile(join(hooksDir, "command-guard.sh"), "utf-8");
     const postScript = await readFile(join(hooksDir, "lint-on-save.sh"), "utf-8");
 
@@ -452,7 +452,7 @@ describe("script isolation", () => {
 
     await generateHooks({ projectDir: tmpDir, config });
 
-    const hooksDir = join(tmpDir, ".claude/hooks");
+    const hooksDir = join(tmpDir, ".omh/hooks");
 
     // Run command-guard alone — should not error
     const cgResult = runHookScript(
@@ -497,7 +497,7 @@ describe("script isolation", () => {
 
     await generateHooks({ projectDir: tmpDir, config });
 
-    const hooksDir = join(tmpDir, ".claude/hooks");
+    const hooksDir = join(tmpDir, ".omh/hooks");
     const cgScript = await readFile(join(hooksDir, "command-guard.sh"), "utf-8");
     const bgScript = await readFile(join(hooksDir, "branch-guard.sh"), "utf-8");
 

--- a/tests/integration/tdd-guard-execution.test.ts
+++ b/tests/integration/tdd-guard-execution.test.ts
@@ -45,7 +45,7 @@ describe("tdd-guard execution", () => {
     scriptPath = join(tmpDir, "catalog-tdd-guard.sh");
     await writeFile(scriptPath, wrapped, { mode: 0o755 });
     // Ensure state dir exists
-    await mkdir(join(tmpDir, ".claude/hooks/.state"), { recursive: true });
+    await mkdir(join(tmpDir, ".omh/state"), { recursive: true });
   });
 
   afterEach(async () => {
@@ -73,7 +73,7 @@ describe("tdd-guard execution", () => {
     "allows source file edit when test file was recorded in edit-history",
     async () => {
       // Write edit-history with a test file pre-recorded
-      const historyPath = join(tmpDir, ".claude/hooks/.state/edit-history.json");
+      const historyPath = join(tmpDir, ".omh/state/tdd-edits.json");
       await writeFile(
         historyPath,
         JSON.stringify({ edits: ["tests/unit/event-logger.test.ts"] }),
@@ -116,7 +116,7 @@ describe("tdd-guard execution", () => {
   it.runIf(hasJq())(
     "allows test file edit and records it in edit-history",
     async () => {
-      const historyPath = join(tmpDir, ".claude/hooks/.state/edit-history.json");
+      const historyPath = join(tmpDir, ".omh/state/tdd-edits.json");
       // Start with empty history
       await writeFile(historyPath, JSON.stringify({ edits: [] }));
 
@@ -142,7 +142,7 @@ describe("tdd-guard execution", () => {
   it.runIf(hasJq())(
     "blocks second source edit after first passed — test record consumed",
     async () => {
-      const historyPath = join(tmpDir, ".claude/hooks/.state/edit-history.json");
+      const historyPath = join(tmpDir, ".omh/state/tdd-edits.json");
       // Turn 1: record test file
       await writeFile(historyPath, JSON.stringify({ edits: ["tests/unit/event-logger.test.ts"] }));
 
@@ -200,7 +200,7 @@ describe("tdd-guard execution (Kotlin/JVM params)", () => {
     const wrapped = wrapWithLogger(rendered, "PreToolUse");
     scriptPath = join(tmpDir, "catalog-tdd-guard.sh");
     await writeFile(scriptPath, wrapped, { mode: 0o755 });
-    await mkdir(join(tmpDir, ".claude/hooks/.state"), { recursive: true });
+    await mkdir(join(tmpDir, ".omh/state"), { recursive: true });
   });
 
   afterEach(async () => {
@@ -210,7 +210,7 @@ describe("tdd-guard execution (Kotlin/JVM params)", () => {
   it.runIf(hasJq())(
     "allows Kotlin source edit when JVM-style test file (IoViewTest.kt) was recorded",
     async () => {
-      const historyPath = join(tmpDir, ".claude/hooks/.state/edit-history.json");
+      const historyPath = join(tmpDir, ".omh/state/tdd-edits.json");
       await writeFile(
         historyPath,
         JSON.stringify({ edits: ["app/src/test/java/com/example/IoViewTest.kt"] }),

--- a/tests/unit/agents-md-generator.test.ts
+++ b/tests/unit/agents-md-generator.test.ts
@@ -131,6 +131,9 @@ describe("generateAgentsMd", () => {
 
     const posAlpha = result.indexOf("<!-- oh-my-harness:start:alpha -->");
     const posBeta = result.indexOf("<!-- oh-my-harness:start:beta -->");
+    // Both markers must exist (guard against false-positive ordering on -1)
+    expect(posAlpha).toBeGreaterThan(-1);
+    expect(posBeta).toBeGreaterThan(-1);
     expect(posBeta).toBeLessThan(posAlpha);
   });
 });

--- a/tests/unit/agents-md-generator.test.ts
+++ b/tests/unit/agents-md-generator.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { generateAgentsMd } from "../../src/generators/agents-md.js";
+import type { MergedConfig } from "../../src/core/preset-types.js";
+
+function makeMergedConfig(overrides: Partial<MergedConfig> = {}): MergedConfig {
+  return {
+    presets: [],
+    variables: {},
+    claudeMdSections: [],
+    hooks: { preToolUse: [], postToolUse: [] },
+    settings: { permissions: { allow: [], deny: [] } },
+    ...overrides,
+  };
+}
+
+describe("generateAgentsMd", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-agents-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates AGENTS.md (not CLAUDE.md) with same managed sections", async () => {
+    const config = makeMergedConfig({
+      claudeMdSections: [
+        { id: "rules", title: "Rules", content: "## Rules\n- be tidy", priority: 10 },
+      ],
+    });
+
+    const result = await generateAgentsMd({ projectDir: tmpDir, config });
+
+    expect(result).toContain("<!-- oh-my-harness:start:rules -->");
+    expect(result).toContain("- be tidy");
+    expect(result).toContain("<!-- oh-my-harness:end:rules -->");
+
+    const written = await fs.readFile(path.join(tmpDir, "AGENTS.md"), "utf8");
+    expect(written).toBe(result);
+
+    // Should not write CLAUDE.md
+    await expect(fs.access(path.join(tmpDir, "CLAUDE.md"))).rejects.toThrow();
+  });
+
+  it("preserves user content outside managed markers", async () => {
+    const existing = "# Project\n\nUser-authored notes.\n";
+    await fs.writeFile(path.join(tmpDir, "AGENTS.md"), existing, "utf8");
+
+    const config = makeMergedConfig({
+      claudeMdSections: [
+        { id: "rules", title: "Rules", content: "## Rules\n- rule 1", priority: 50 },
+      ],
+    });
+
+    const result = await generateAgentsMd({ projectDir: tmpDir, config });
+
+    expect(result).toContain("User-authored notes.");
+    expect(result).toContain("- rule 1");
+  });
+
+  it("orders sections by priority (lower first)", async () => {
+    const config = makeMergedConfig({
+      claudeMdSections: [
+        { id: "second", title: "B", content: "## B", priority: 20 },
+        { id: "first", title: "A", content: "## A", priority: 10 },
+      ],
+    });
+
+    const result = await generateAgentsMd({ projectDir: tmpDir, config });
+
+    const posFirst = result.indexOf("<!-- oh-my-harness:start:first -->");
+    const posSecond = result.indexOf("<!-- oh-my-harness:start:second -->");
+    expect(posFirst).toBeLessThan(posSecond);
+  });
+
+  it("removes managed sections that are no longer in config", async () => {
+    await generateAgentsMd({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        claudeMdSections: [{ id: "rule-x", title: "X", content: "## X\n- x", priority: 10 }],
+      }),
+    });
+
+    const result = await generateAgentsMd({
+      projectDir: tmpDir,
+      config: makeMergedConfig({ claudeMdSections: [] }),
+    });
+
+    expect(result).not.toContain("rule-x");
+    expect(result).not.toContain("- x");
+  });
+
+  it("is idempotent on re-run", async () => {
+    const config = makeMergedConfig({
+      claudeMdSections: [{ id: "rules", title: "R", content: "## R\n- r", priority: 50 }],
+    });
+
+    const first = await generateAgentsMd({ projectDir: tmpDir, config });
+    const second = await generateAgentsMd({ projectDir: tmpDir, config });
+
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/agents-md-generator.test.ts
+++ b/tests/unit/agents-md-generator.test.ts
@@ -105,4 +105,32 @@ describe("generateAgentsMd", () => {
 
     expect(second).toBe(first);
   });
+
+  it("re-orders existing managed sections when priorities change", async () => {
+    // First run: A=10, B=20 → A appears first
+    await generateAgentsMd({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        claudeMdSections: [
+          { id: "alpha", title: "A", content: "## A", priority: 10 },
+          { id: "beta", title: "B", content: "## B", priority: 20 },
+        ],
+      }),
+    });
+
+    // Second run: priorities flipped → B should now appear first
+    const result = await generateAgentsMd({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        claudeMdSections: [
+          { id: "alpha", title: "A", content: "## A", priority: 20 },
+          { id: "beta", title: "B", content: "## B", priority: 10 },
+        ],
+      }),
+    });
+
+    const posAlpha = result.indexOf("<!-- oh-my-harness:start:alpha -->");
+    const posBeta = result.indexOf("<!-- oh-my-harness:start:beta -->");
+    expect(posBeta).toBeLessThan(posAlpha);
+  });
 });

--- a/tests/unit/catalog-converter.test.ts
+++ b/tests/unit/catalog-converter.test.ts
@@ -145,11 +145,11 @@ describe("convertHookEntries", () => {
     expect(result.errors).toHaveLength(0);
     const command = result.hooksConfig["PreToolUse"][0].command;
     expect(command).not.toContain(projectDir);
-    expect(command).toBe(".claude/hooks/tdd-guard.sh");
+    expect(command).toBe(".omh/hooks/tdd-guard.sh");
 
     // scripts map key should also use relative path
     const scriptKeys = [...result.scripts.keys()];
-    expect(scriptKeys[0]).toBe(".claude/hooks/tdd-guard.sh");
+    expect(scriptKeys[0]).toBe(".omh/hooks/tdd-guard.sh");
   });
 
   it("allows duplicate block ids with different params (multi-instance)", async () => {

--- a/tests/unit/claude-md-generator.test.ts
+++ b/tests/unit/claude-md-generator.test.ts
@@ -163,6 +163,8 @@ More user content.
 
     const posAlpha = result.indexOf("<!-- oh-my-harness:start:alpha -->");
     const posBeta = result.indexOf("<!-- oh-my-harness:start:beta -->");
+    expect(posAlpha).toBeGreaterThan(-1);
+    expect(posBeta).toBeGreaterThan(-1);
     expect(posBeta).toBeLessThan(posAlpha);
   });
 

--- a/tests/unit/claude-md-generator.test.ts
+++ b/tests/unit/claude-md-generator.test.ts
@@ -138,6 +138,34 @@ More user content.
     expect(written).toBe("");
   });
 
+  it("re-orders existing managed sections when priorities change", async () => {
+    // First run: A=10, B=20 → A appears first
+    await generateClaudeMd({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        claudeMdSections: [
+          { id: "alpha", title: "A", content: "## A", priority: 10 },
+          { id: "beta", title: "B", content: "## B", priority: 20 },
+        ],
+      }),
+    });
+
+    // Second run: priorities flipped → B should now appear first
+    const result = await generateClaudeMd({
+      projectDir: tmpDir,
+      config: makeMergedConfig({
+        claudeMdSections: [
+          { id: "alpha", title: "A", content: "## A", priority: 20 },
+          { id: "beta", title: "B", content: "## B", priority: 10 },
+        ],
+      }),
+    });
+
+    const posAlpha = result.indexOf("<!-- oh-my-harness:start:alpha -->");
+    const posBeta = result.indexOf("<!-- oh-my-harness:start:beta -->");
+    expect(posBeta).toBeLessThan(posAlpha);
+  });
+
   it("includes sections from multiple presets", async () => {
     const config = makeMergedConfig({
       presets: ["_base", "nextjs"],

--- a/tests/unit/cli-test.test.ts
+++ b/tests/unit/cli-test.test.ts
@@ -74,7 +74,7 @@ describe("testCommand", () => {
 
   it("runs tests and returns results for registered hooks with matching scripts", async () => {
     // Set up settings.json with a lockfile-guard hook
-    const hooksDir = path.join(tmpDir, ".claude", "hooks");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
     await fs.mkdir(hooksDir, { recursive: true });
 
     // Write a lockfile-guard script that blocks package-lock.json
@@ -96,7 +96,7 @@ fi
         PreToolUse: [
           {
             matcher: "Edit",
-            hooks: [{ type: "command", command: "bash .claude/hooks/catalog-lockfile-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/catalog-lockfile-guard.sh" }],
           },
         ],
       },
@@ -147,8 +147,8 @@ fi
   });
 
   it("generates block-based test cases merged with enforcement cases without duplicates", async () => {
-    const hooksDir = path.join(tmpDir, ".claude", "hooks");
-    const stateDir = path.join(tmpDir, ".claude", "hooks", ".state");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
+    const stateDir = path.join(tmpDir, ".omh", "state");
     await fs.mkdir(hooksDir, { recursive: true });
     await fs.mkdir(stateDir, { recursive: true });
 
@@ -164,7 +164,7 @@ if echo "$FILE_PATH" | grep -qE '\\.(test|spec)\\.(ts|tsx|js|jsx)$'; then
   exit 0
 fi
 if echo "$FILE_PATH" | grep -qE '\\.(ts|tsx|js|jsx)$'; then
-  HISTORY=".claude/hooks/.state/edit-history.json"
+  HISTORY=".omh/state/tdd-edits.json"
   if [[ ! -f "$HISTORY" ]]; then
     echo '{"decision":"block","reason":"TDD: write test first"}'
     exit 0
@@ -183,7 +183,7 @@ exit 0
         PreToolUse: [
           {
             matcher: "Edit",
-            hooks: [{ type: "command", command: "bash .claude/hooks/catalog-tdd-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/catalog-tdd-guard.sh" }],
           },
         ],
       },

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { parse } from "smol-toml";
 import {
   generateCodexConfig,
   buildCodexHooks,
@@ -78,102 +79,119 @@ describe("buildCodexHooks", () => {
 });
 
 describe("buildCodexConfigToml", () => {
-  it("creates a fresh config.toml with [features] codex_hooks=true block", () => {
+  it("creates a fresh config.toml with [features] codex_hooks=true", () => {
     const result = buildCodexConfigToml("");
-    expect(result).toContain("# >>> oh-my-harness >>>");
-    expect(result).toContain("[features]");
-    expect(result).toContain("codex_hooks = true");
-    expect(result).toContain("# <<< oh-my-harness <<<");
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(result).toMatch(/^# Managed by oh-my-harness/);
   });
 
-  it("upserts the managed block in an existing config.toml without losing user content", () => {
-    const existing = `# user comment
-[mcp_servers.foo]
+  it("preserves user tables and keys when adding [features] codex_hooks", () => {
+    const existing = `[mcp_servers.foo]
 command = "bar"
+args = ["--flag"]
 `;
     const result = buildCodexConfigToml(existing);
-    expect(result).toContain("# user comment");
-    expect(result).toContain("[mcp_servers.foo]");
-    expect(result).toContain("codex_hooks = true");
+    const parsed = parse(result) as {
+      features?: { codex_hooks?: unknown };
+      mcp_servers?: { foo?: { command?: unknown; args?: unknown } };
+    };
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.mcp_servers?.foo?.command).toBe("bar");
+    expect(parsed.mcp_servers?.foo?.args).toEqual(["--flag"]);
   });
 
-  it("replaces a previous managed block on re-run (idempotent)", () => {
+  it("is idempotent — running twice produces identical output", () => {
     const first = buildCodexConfigToml("");
     const second = buildCodexConfigToml(first);
-    // Should still contain exactly one managed block
-    const matches = second.match(/# >>> oh-my-harness >>>/g) ?? [];
-    expect(matches).toHaveLength(1);
+    expect(second).toBe(first);
   });
 
-  it("does NOT duplicate [features] when user already has one (TOML v1.0 violation)", () => {
-    // User wrote their own [features] table with another key
-    const existing = `# my settings
-[features]
+  it("does NOT duplicate [features] when user already has one", () => {
+    const existing = `[features]
 some_other_flag = true
 
 [mcp_servers.foo]
 command = "bar"
 `;
     const result = buildCodexConfigToml(existing);
-
-    // Must contain exactly one [features] header
-    const featuresHeaders = result.match(/^\[features\]\s*$/gm) ?? [];
-    expect(featuresHeaders).toHaveLength(1);
-
-    // Must preserve user's key
-    expect(result).toContain("some_other_flag = true");
-    // Must add our key
-    expect(result).toContain("codex_hooks = true");
-    // Must preserve other tables
-    expect(result).toContain("[mcp_servers.foo]");
+    const parsed = parse(result) as {
+      features?: { codex_hooks?: unknown; some_other_flag?: unknown };
+      mcp_servers?: { foo?: { command?: unknown } };
+    };
+    // Single [features] table containing both keys
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.some_other_flag).toBe(true);
+    // User's other tables preserved
+    expect(parsed.mcp_servers?.foo?.command).toBe("bar");
   });
 
-  it("injecting into an existing [features] table is idempotent", () => {
-    const existing = `[features]
-some_other_flag = true
-`;
-    const first = buildCodexConfigToml(existing);
-    const second = buildCodexConfigToml(first);
-    const third = buildCodexConfigToml(second);
-
-    expect(third).toBe(second);
-    const featuresHeaders = third.match(/^\[features\]\s*$/gm) ?? [];
-    expect(featuresHeaders).toHaveLength(1);
-    expect(third).toContain("some_other_flag = true");
-    expect(third).toContain("codex_hooks = true");
-  });
-
-  it("does NOT duplicate codex_hooks when user already set it without marker", () => {
-    // Edge case: user manually enabled the flag, perhaps from a guide,
-    // before running omh init. We must replace the existing key with our
-    // marker block, not add a second one.
+  it("does NOT duplicate codex_hooks when user already set it without our markers", () => {
     const existing = `[features]
 codex_hooks = true
 some_other_flag = true
 `;
     const result = buildCodexConfigToml(existing);
-
-    // Only one codex_hooks key in the whole file
-    const codexLines = result.match(/codex_hooks\s*=/g) ?? [];
-    expect(codexLines).toHaveLength(1);
-    // Must be inside our managed marker
-    expect(result).toMatch(
-      /# >>> oh-my-harness >>>\ncodex_hooks = true\n# <<< oh-my-harness <<</,
-    );
-    // User's other key preserved
-    expect(result).toContain("some_other_flag = true");
+    const parsed = parse(result) as {
+      features?: { codex_hooks?: unknown; some_other_flag?: unknown };
+    };
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.some_other_flag).toBe(true);
+    // Only one TOML-level assignment of the key (parser would have rejected
+    // the file if there were two, but verify the rendered output too).
+    const codexAssignments = result.match(/^[ \t]*codex_hooks\s*=/gm) ?? [];
+    expect(codexAssignments).toHaveLength(1);
   });
 
-  it("upgrades existing codex_hooks=false to true via marker replacement", () => {
+  it("upgrades existing codex_hooks=false to true", () => {
     const existing = `[features]
 codex_hooks = false
 `;
     const result = buildCodexConfigToml(existing);
-
-    const codexLines = result.match(/codex_hooks\s*=/g) ?? [];
-    expect(codexLines).toHaveLength(1);
-    expect(result).toContain("codex_hooks = true");
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
     expect(result).not.toContain("codex_hooks = false");
+  });
+
+  it("handles [[array-table]] and other table forms without corrupting them", () => {
+    const existing = `[features]
+some_other_flag = true
+
+[[mcp_servers]]
+name = "first"
+
+[[mcp_servers]]
+name = "second"
+`;
+    const result = buildCodexConfigToml(existing);
+    const parsed = parse(result) as {
+      features?: { codex_hooks?: unknown };
+      mcp_servers?: Array<{ name?: unknown }>;
+    };
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.mcp_servers).toHaveLength(2);
+    expect(parsed.mcp_servers?.[0].name).toBe("first");
+    expect(parsed.mcp_servers?.[1].name).toBe("second");
+  });
+
+  it("handles inline comments on existing keys without breaking parse", () => {
+    const existing = `[features]
+codex_hooks = false # legacy
+some_other_flag = true # keep this
+`;
+    const result = buildCodexConfigToml(existing);
+    const parsed = parse(result) as {
+      features?: { codex_hooks?: unknown; some_other_flag?: unknown };
+    };
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.some_other_flag).toBe(true);
+  });
+
+  it("falls back to a clean config when existing TOML is malformed", () => {
+    const existing = "this is [not valid TOML";
+    const result = buildCodexConfigToml(existing);
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
   });
 });
 
@@ -210,10 +228,11 @@ describe("generateCodexConfig", () => {
     expect(hooksJson.hooks.PreToolUse[0].matcher).toBe("Bash");
 
     const toml = await fs.readFile(path.join(tmpDir, ".codex/config.toml"), "utf8");
-    expect(toml).toContain("codex_hooks = true");
+    const parsed = parse(toml) as { features?: { codex_hooks?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
   });
 
-  it("preserves existing config.toml content outside managed block", async () => {
+  it("preserves existing config.toml structure outside [features]", async () => {
     const codexDir = path.join(tmpDir, ".codex");
     await fs.mkdir(codexDir, { recursive: true });
     await fs.writeFile(
@@ -225,8 +244,12 @@ describe("generateCodexConfig", () => {
     await generateCodexConfig({ projectDir: tmpDir, hooksOutput: { hooksConfig: {}, generatedFiles: [] } });
 
     const toml = await fs.readFile(path.join(codexDir, "config.toml"), "utf8");
-    expect(toml).toContain("[mcp_servers.foo]");
-    expect(toml).toContain("codex_hooks = true");
+    const parsed = parse(toml) as {
+      features?: { codex_hooks?: unknown };
+      mcp_servers?: { foo?: { command?: unknown } };
+    };
+    expect(parsed.mcp_servers?.foo?.command).toBe("bar");
+    expect(parsed.features?.codex_hooks).toBe(true);
   });
 
   it("emits empty hooks.json when no hooks present", async () => {

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import {
+  generateCodexConfig,
+  buildCodexHooks,
+  buildCodexConfigToml,
+} from "../../src/generators/codex-config.js";
+import type { HooksOutput } from "../../src/generators/hooks.js";
+
+function makeHooksOutput(overrides: Partial<HooksOutput["hooksConfig"]> = {}): HooksOutput {
+  return {
+    hooksConfig: { ...overrides },
+    generatedFiles: [],
+  };
+}
+
+describe("buildCodexHooks", () => {
+  it("passes Codex-supported events through unchanged", () => {
+    const out = makeHooksOutput({
+      PreToolUse: [
+        { matcher: "Bash", hooks: [{ type: "command", command: "bash /p/.omh/hooks/x.sh" }] },
+      ],
+      PostToolUse: [
+        { matcher: "", hooks: [{ type: "command", command: "bash /p/.omh/hooks/y.sh" }] },
+      ],
+      SessionStart: [
+        { matcher: "startup", hooks: [{ type: "command", command: "bash /p/.omh/hooks/z.sh" }] },
+      ],
+    });
+
+    const { codexHooks, skipped } = buildCodexHooks(out);
+
+    expect(skipped).toEqual([]);
+    expect(codexHooks.hooks.PreToolUse).toEqual(out.hooksConfig.PreToolUse);
+    expect(codexHooks.hooks.PostToolUse).toEqual(out.hooksConfig.PostToolUse);
+    expect(codexHooks.hooks.SessionStart).toEqual(out.hooksConfig.SessionStart);
+  });
+
+  it("drops Codex-unsupported events with skipped report", () => {
+    const out = makeHooksOutput({
+      Notification: [{ matcher: "", hooks: [{ type: "command", command: "bash /p/notify.sh" }] }],
+      ConfigChange: [{ matcher: "", hooks: [{ type: "command", command: "bash /p/audit.sh" }] }],
+      WorktreeCreate: [{ matcher: "", hooks: [{ type: "command", command: "bash /p/wt.sh" }] }],
+      PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "bash /p/g.sh" }] }],
+    });
+
+    const { codexHooks, skipped } = buildCodexHooks(out);
+
+    expect(codexHooks.hooks).toHaveProperty("PreToolUse");
+    expect(codexHooks.hooks).not.toHaveProperty("Notification");
+    expect(codexHooks.hooks).not.toHaveProperty("ConfigChange");
+    expect(codexHooks.hooks).not.toHaveProperty("WorktreeCreate");
+    expect(skipped.sort()).toEqual(["ConfigChange", "Notification", "WorktreeCreate"].sort());
+  });
+
+  it("normalizes Edit|Write matcher to also include apply_patch (Codex alias)", () => {
+    const out = makeHooksOutput({
+      PreToolUse: [
+        { matcher: "Edit|Write", hooks: [{ type: "command", command: "bash /p/g.sh" }] },
+      ],
+    });
+
+    const { codexHooks } = buildCodexHooks(out);
+
+    expect(codexHooks.hooks.PreToolUse[0].matcher).toBe("Edit|Write|apply_patch");
+  });
+
+  it("leaves unrelated matchers alone", () => {
+    const out = makeHooksOutput({
+      PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "bash /p/g.sh" }] }],
+    });
+
+    const { codexHooks } = buildCodexHooks(out);
+    expect(codexHooks.hooks.PreToolUse[0].matcher).toBe("Bash");
+  });
+});
+
+describe("buildCodexConfigToml", () => {
+  it("creates a fresh config.toml with [features] codex_hooks=true block", () => {
+    const result = buildCodexConfigToml("");
+    expect(result).toContain("# >>> oh-my-harness >>>");
+    expect(result).toContain("[features]");
+    expect(result).toContain("codex_hooks = true");
+    expect(result).toContain("# <<< oh-my-harness <<<");
+  });
+
+  it("upserts the managed block in an existing config.toml without losing user content", () => {
+    const existing = `# user comment
+[mcp_servers.foo]
+command = "bar"
+`;
+    const result = buildCodexConfigToml(existing);
+    expect(result).toContain("# user comment");
+    expect(result).toContain("[mcp_servers.foo]");
+    expect(result).toContain("codex_hooks = true");
+  });
+
+  it("replaces a previous managed block on re-run (idempotent)", () => {
+    const first = buildCodexConfigToml("");
+    const second = buildCodexConfigToml(first);
+    // Should still contain exactly one managed block
+    const matches = second.match(/# >>> oh-my-harness >>>/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+});
+
+describe("generateCodexConfig", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-codex-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes .codex/hooks.json and .codex/config.toml", async () => {
+    const hooksOutput: HooksOutput = {
+      hooksConfig: {
+        PreToolUse: [
+          { matcher: "Bash", hooks: [{ type: "command", command: `bash "${tmpDir}/.omh/hooks/g.sh"` }] },
+        ],
+      },
+      generatedFiles: [],
+    };
+
+    const files = await generateCodexConfig({ projectDir: tmpDir, hooksOutput });
+
+    expect(files).toEqual([
+      path.join(tmpDir, ".codex/hooks.json"),
+      path.join(tmpDir, ".codex/config.toml"),
+    ]);
+
+    const hooksJson = JSON.parse(await fs.readFile(path.join(tmpDir, ".codex/hooks.json"), "utf8"));
+    expect(hooksJson.hooks.PreToolUse).toHaveLength(1);
+    expect(hooksJson.hooks.PreToolUse[0].matcher).toBe("Bash");
+
+    const toml = await fs.readFile(path.join(tmpDir, ".codex/config.toml"), "utf8");
+    expect(toml).toContain("codex_hooks = true");
+  });
+
+  it("preserves existing config.toml content outside managed block", async () => {
+    const codexDir = path.join(tmpDir, ".codex");
+    await fs.mkdir(codexDir, { recursive: true });
+    await fs.writeFile(
+      path.join(codexDir, "config.toml"),
+      `[mcp_servers.foo]\ncommand = "bar"\n`,
+      "utf8",
+    );
+
+    await generateCodexConfig({ projectDir: tmpDir, hooksOutput: { hooksConfig: {}, generatedFiles: [] } });
+
+    const toml = await fs.readFile(path.join(codexDir, "config.toml"), "utf8");
+    expect(toml).toContain("[mcp_servers.foo]");
+    expect(toml).toContain("codex_hooks = true");
+  });
+
+  it("emits empty hooks.json when no hooks present", async () => {
+    const files = await generateCodexConfig({
+      projectDir: tmpDir,
+      hooksOutput: { hooksConfig: {}, generatedFiles: [] },
+    });
+
+    expect(files).toHaveLength(2);
+    const hooksJson = JSON.parse(await fs.readFile(path.join(tmpDir, ".codex/hooks.json"), "utf8"));
+    expect(hooksJson).toEqual({ hooks: {} });
+  });
+});

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -142,6 +142,39 @@ some_other_flag = true
     expect(third).toContain("some_other_flag = true");
     expect(third).toContain("codex_hooks = true");
   });
+
+  it("does NOT duplicate codex_hooks when user already set it without marker", () => {
+    // Edge case: user manually enabled the flag, perhaps from a guide,
+    // before running omh init. We must replace the existing key with our
+    // marker block, not add a second one.
+    const existing = `[features]
+codex_hooks = true
+some_other_flag = true
+`;
+    const result = buildCodexConfigToml(existing);
+
+    // Only one codex_hooks key in the whole file
+    const codexLines = result.match(/codex_hooks\s*=/g) ?? [];
+    expect(codexLines).toHaveLength(1);
+    // Must be inside our managed marker
+    expect(result).toMatch(
+      /# >>> oh-my-harness >>>\ncodex_hooks = true\n# <<< oh-my-harness <<</,
+    );
+    // User's other key preserved
+    expect(result).toContain("some_other_flag = true");
+  });
+
+  it("upgrades existing codex_hooks=false to true via marker replacement", () => {
+    const existing = `[features]
+codex_hooks = false
+`;
+    const result = buildCodexConfigToml(existing);
+
+    const codexLines = result.match(/codex_hooks\s*=/g) ?? [];
+    expect(codexLines).toHaveLength(1);
+    expect(result).toContain("codex_hooks = true");
+    expect(result).not.toContain("codex_hooks = false");
+  });
 });
 
 describe("generateCodexConfig", () => {

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -187,11 +187,12 @@ some_other_flag = true # keep this
     expect(parsed.features?.some_other_flag).toBe(true);
   });
 
-  it("falls back to a clean config when existing TOML is malformed", () => {
+  it("refuses to overwrite when existing TOML is malformed (preserves user content)", () => {
+    // Earlier behavior was a silent rewrite that destroyed any user MCP
+    // server entries on the next sync. Now we throw so the user can fix
+    // the syntax error manually before re-running.
     const existing = "this is [not valid TOML";
-    const result = buildCodexConfigToml(existing);
-    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
-    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(() => buildCodexConfigToml(existing)).toThrow(/invalid TOML/);
   });
 
   it("does NOT throw when existing `features` is a scalar boolean", () => {
@@ -227,7 +228,7 @@ describe("generateCodexConfig", () => {
     const hooksOutput: HooksOutput = {
       hooksConfig: {
         PreToolUse: [
-          { matcher: "Bash", hooks: [{ type: "command", command: `bash "${tmpDir}/.omh/hooks/g.sh"` }] },
+          { matcher: "Bash", hooks: [{ type: "command", command: `bash '${tmpDir}/.omh/hooks/g.sh'` }] },
         ],
       },
       generatedFiles: [],

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -104,6 +104,44 @@ command = "bar"
     const matches = second.match(/# >>> oh-my-harness >>>/g) ?? [];
     expect(matches).toHaveLength(1);
   });
+
+  it("does NOT duplicate [features] when user already has one (TOML v1.0 violation)", () => {
+    // User wrote their own [features] table with another key
+    const existing = `# my settings
+[features]
+some_other_flag = true
+
+[mcp_servers.foo]
+command = "bar"
+`;
+    const result = buildCodexConfigToml(existing);
+
+    // Must contain exactly one [features] header
+    const featuresHeaders = result.match(/^\[features\]\s*$/gm) ?? [];
+    expect(featuresHeaders).toHaveLength(1);
+
+    // Must preserve user's key
+    expect(result).toContain("some_other_flag = true");
+    // Must add our key
+    expect(result).toContain("codex_hooks = true");
+    // Must preserve other tables
+    expect(result).toContain("[mcp_servers.foo]");
+  });
+
+  it("injecting into an existing [features] table is idempotent", () => {
+    const existing = `[features]
+some_other_flag = true
+`;
+    const first = buildCodexConfigToml(existing);
+    const second = buildCodexConfigToml(first);
+    const third = buildCodexConfigToml(second);
+
+    expect(third).toBe(second);
+    const featuresHeaders = third.match(/^\[features\]\s*$/gm) ?? [];
+    expect(featuresHeaders).toHaveLength(1);
+    expect(third).toContain("some_other_flag = true");
+    expect(third).toContain("codex_hooks = true");
+  });
 });
 
 describe("generateCodexConfig", () => {

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -193,6 +193,23 @@ some_other_flag = true # keep this
     const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
     expect(parsed.features?.codex_hooks).toBe(true);
   });
+
+  it("does NOT throw when existing `features` is a scalar boolean", () => {
+    // Edge case: user wrote `features = true` at top level (valid TOML).
+    // Earlier code tried to assign codex_hooks onto a boolean → TypeError.
+    const existing = `features = true\n`;
+    expect(() => buildCodexConfigToml(existing)).not.toThrow();
+    const result = buildCodexConfigToml(existing);
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
+  });
+
+  it("overwrites a non-table `features` value (array) with a proper table", () => {
+    const existing = `features = [1, 2, 3]\n`;
+    const result = buildCodexConfigToml(existing);
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
+  });
 });
 
 describe("generateCodexConfig", () => {

--- a/tests/unit/config-audit.test.ts
+++ b/tests/unit/config-audit.test.ts
@@ -28,4 +28,13 @@ describe("configAudit block", () => {
   it("template no longer writes to a separate .log file", () => {
     expect(configAudit.template).not.toContain(".log");
   });
+
+  it("template tolerates jq failure under set -euo pipefail", () => {
+    // META=$(jq ...) under errexit would abort if jq fails; the fallback line
+    // never executes. Mitigation: '|| true' (or '|| echo {...}') after the jq.
+    const tpl = configAudit.template;
+    const jqLineMatch = tpl.match(/META=\$\(jq[^\n]+\)/);
+    expect(jqLineMatch).not.toBeNull();
+    expect(jqLineMatch![0]).toMatch(/\|\|\s*(true|echo)/);
+  });
 });

--- a/tests/unit/config-audit.test.ts
+++ b/tests/unit/config-audit.test.ts
@@ -10,15 +10,8 @@ describe("configAudit block", () => {
     expect(configAudit.canBlock).toBe(false);
   });
 
-  it("has logFile param with default", () => {
-    const param = configAudit.params.find((p) => p.name === "logFile");
-    expect(param).toBeDefined();
-    expect(param!.type).toBe("string");
-    expect(param!.default).toBe(".claude/hooks/.state/config-audit.log");
-  });
-
-  it("template uses triple-stash for logFile", () => {
-    expect(configAudit.template).toContain("{{{logFile}}}");
+  it("has no params (uses unified events.jsonl via _log_event wrapper)", () => {
+    expect(configAudit.params).toEqual([]);
   });
 
   it("template reads source and file_path from input", () => {
@@ -26,7 +19,13 @@ describe("configAudit block", () => {
     expect(configAudit.template).toContain(".file_path");
   });
 
-  it("does not contain _log_event wrapper", () => {
-    expect(configAudit.template).not.toContain("_log_event");
+  it("template emits a meta JSON object via _log_event", () => {
+    expect(configAudit.template).toContain("_log_event");
+    expect(configAudit.template).toContain("\"source\"");
+    expect(configAudit.template).toContain("\"file\"");
+  });
+
+  it("template no longer writes to a separate .log file", () => {
+    expect(configAudit.template).not.toContain(".log");
   });
 });

--- a/tests/unit/event-logger.test.ts
+++ b/tests/unit/event-logger.test.ts
@@ -31,7 +31,7 @@ describe("appendEvent", () => {
 
     await appendEvent(tmpDir, event);
 
-    const stateDir = path.join(tmpDir, ".claude/hooks/.state");
+    const stateDir = path.join(tmpDir, ".omh/state");
     const filePath = path.join(stateDir, "events.jsonl");
     const content = await fs.readFile(filePath, "utf-8");
     const lines = content.trim().split("\n");
@@ -87,7 +87,7 @@ describe("readEvents", () => {
   });
 
   it("잘못된 JSON 줄 무시 (graceful)", async () => {
-    const stateDir = path.join(tmpDir, ".claude/hooks/.state");
+    const stateDir = path.join(tmpDir, ".omh/state");
     await fs.mkdir(stateDir, { recursive: true });
     const filePath = path.join(stateDir, "events.jsonl");
 
@@ -115,7 +115,7 @@ describe("readEvents", () => {
   });
 
   it("'error' decision 이벤트도 정상 파싱", async () => {
-    const stateDir = path.join(tmpDir, ".claude/hooks/.state");
+    const stateDir = path.join(tmpDir, ".omh/state");
     await fs.mkdir(stateDir, { recursive: true });
     const filePath = path.join(stateDir, "events.jsonl");
 
@@ -136,7 +136,7 @@ describe("readEvents", () => {
   });
 
   it("필수 필드 누락된 JSON은 무시 (런타임 검증)", async () => {
-    const stateDir = path.join(tmpDir, ".claude/hooks/.state");
+    const stateDir = path.join(tmpDir, ".omh/state");
     await fs.mkdir(stateDir, { recursive: true });
     const filePath = path.join(stateDir, "events.jsonl");
 

--- a/tests/unit/harness-tester.test.ts
+++ b/tests/unit/harness-tester.test.ts
@@ -126,7 +126,7 @@ describe("getRegisteredHooks", () => {
         PreToolUse: [
           {
             matcher: "Edit",
-            hooks: [{ type: "command", command: "bash .claude/hooks/file-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/file-guard.sh" }],
           },
         ],
       },
@@ -140,7 +140,7 @@ describe("getRegisteredHooks", () => {
     expect(hooks).toHaveLength(1);
     expect(hooks[0].event).toBe("PreToolUse");
     expect(hooks[0].matcher).toBe("Edit");
-    expect(hooks[0].command).toBe("bash .claude/hooks/file-guard.sh");
+    expect(hooks[0].command).toBe("bash .omh/hooks/file-guard.sh");
   });
 
   it("extracts PostToolUse hooks from settings.json", async () => {
@@ -149,7 +149,7 @@ describe("getRegisteredHooks", () => {
         PostToolUse: [
           {
             matcher: "Bash",
-            hooks: [{ type: "command", command: "bash .claude/hooks/command-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/command-guard.sh" }],
           },
         ],
       },
@@ -170,13 +170,13 @@ describe("getRegisteredHooks", () => {
         PreToolUse: [
           {
             matcher: "Edit",
-            hooks: [{ type: "command", command: "bash .claude/hooks/file-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/file-guard.sh" }],
           },
         ],
         PostToolUse: [
           {
             matcher: "Bash",
-            hooks: [{ type: "command", command: "bash .claude/hooks/command-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/command-guard.sh" }],
           },
         ],
       },
@@ -196,7 +196,7 @@ describe("getRegisteredHooks", () => {
         PreToolUse: [
           {
             matcher: "Edit",
-            hooks: [{ type: "other", command: "bash .claude/hooks/file-guard.sh" }],
+            hooks: [{ type: "other", command: "bash .omh/hooks/file-guard.sh" }],
           },
         ],
       },
@@ -215,7 +215,7 @@ describe("getRegisteredHooks", () => {
       hooks: {
         PreToolUse: [
           {
-            hooks: [{ type: "command", command: "bash .claude/hooks/file-guard.sh" }],
+            hooks: [{ type: "command", command: "bash .omh/hooks/file-guard.sh" }],
           },
         ],
       },
@@ -256,7 +256,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "missing script test",
       category: "path-guard",
-      hookScript: ".claude/hooks/nonexistent.sh",
+      hookScript: ".omh/hooks/nonexistent.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "test.ts" } },
       expectation: "block",
     };
@@ -268,7 +268,7 @@ describe("runTestCase", () => {
   });
 
   it("returns passed true when script decision matches expectation", async () => {
-    const scriptDir = path.join(tmpDir, ".claude", "hooks");
+    const scriptDir = path.join(tmpDir, ".omh", "hooks");
     await fs.mkdir(scriptDir, { recursive: true });
     const scriptPath = path.join(scriptDir, "block-guard.sh");
     await fs.writeFile(
@@ -280,7 +280,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "block test",
       category: "path-guard",
-      hookScript: ".claude/hooks/block-guard.sh",
+      hookScript: ".omh/hooks/block-guard.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "dist/test.js" } },
       expectation: "block",
     };
@@ -292,7 +292,7 @@ describe("runTestCase", () => {
   });
 
   it("returns passed false with error message when decision mismatches", async () => {
-    const scriptDir = path.join(tmpDir, ".claude", "hooks");
+    const scriptDir = path.join(tmpDir, ".omh", "hooks");
     await fs.mkdir(scriptDir, { recursive: true });
     const scriptPath = path.join(scriptDir, "allow-guard.sh");
     await fs.writeFile(scriptPath, `#!/bin/bash\nexit 0`, { mode: 0o755 });
@@ -300,7 +300,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "allow but expect block",
       category: "path-guard",
-      hookScript: ".claude/hooks/allow-guard.sh",
+      hookScript: ".omh/hooks/allow-guard.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "dist/test.js" } },
       expectation: "block",
     };
@@ -312,7 +312,7 @@ describe("runTestCase", () => {
   });
 
   it("includes reason from hook output in result", async () => {
-    const scriptDir = path.join(tmpDir, ".claude", "hooks");
+    const scriptDir = path.join(tmpDir, ".omh", "hooks");
     await fs.mkdir(scriptDir, { recursive: true });
     const scriptPath = path.join(scriptDir, "reason-guard.sh");
     await fs.writeFile(
@@ -324,7 +324,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "reason test",
       category: "path-guard",
-      hookScript: ".claude/hooks/reason-guard.sh",
+      hookScript: ".omh/hooks/reason-guard.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "dist/test.js" } },
       expectation: "block",
     };
@@ -337,7 +337,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "missing test",
       category: "path-guard",
-      hookScript: ".claude/hooks/missing.sh",
+      hookScript: ".omh/hooks/missing.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "test.ts" } },
       expectation: "block",
     };
@@ -347,7 +347,7 @@ describe("runTestCase", () => {
   });
 
   it("calls setup before and teardown after running the hook", async () => {
-    const scriptDir = path.join(tmpDir, ".claude", "hooks");
+    const scriptDir = path.join(tmpDir, ".omh", "hooks");
     await fs.mkdir(scriptDir, { recursive: true });
     const scriptPath = path.join(scriptDir, "allow-guard.sh");
     await fs.writeFile(scriptPath, `#!/bin/bash\nexit 0`, { mode: 0o755 });
@@ -356,7 +356,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "setup teardown test",
       category: "path-guard",
-      hookScript: ".claude/hooks/allow-guard.sh",
+      hookScript: ".omh/hooks/allow-guard.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "src/index.ts" } },
       expectation: "allow",
       setup: async () => { callOrder.push("setup"); },
@@ -372,7 +372,7 @@ describe("runTestCase", () => {
     const testCase: TestCase = {
       name: "teardown on error test",
       category: "path-guard",
-      hookScript: ".claude/hooks/nonexistent-will-fail.sh",
+      hookScript: ".omh/hooks/nonexistent-will-fail.sh",
       input: { tool_name: "Edit", tool_input: { file_path: "src/index.ts" } },
       expectation: "allow",
       setup: async () => { callOrder.push("setup"); },
@@ -398,16 +398,16 @@ describe("generateBlockTestCases", () => {
   it("uses registered hook path when provided", () => {
     const entries = [{ block: "path-guard", params: { blockedPaths: ["dist/"] } }];
     const registeredHooks = [
-      { event: "PreToolUse", matcher: "Edit|Write", command: "bash .claude/hooks/harness-file-guard.sh" },
+      { event: "PreToolUse", matcher: "Edit|Write", command: "bash .omh/hooks/harness-file-guard.sh" },
     ];
     const cases = generateBlockTestCases(entries, builtinBlocks, undefined, registeredHooks);
-    expect(cases[0].hookScript).toBe(".claude/hooks/harness-file-guard.sh");
+    expect(cases[0].hookScript).toBe(".omh/hooks/harness-file-guard.sh");
   });
 
   it("falls back to catalog- prefix when no registered hook matches", () => {
     const entries = [{ block: "path-guard", params: { blockedPaths: ["dist/"] } }];
     const cases = generateBlockTestCases(entries, builtinBlocks);
-    expect(cases[0].hookScript).toBe(".claude/hooks/catalog-path-guard.sh");
+    expect(cases[0].hookScript).toBe(".omh/hooks/catalog-path-guard.sh");
   });
 
   it("generates block/allow cases for command-guard with patterns params", () => {

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -351,6 +351,81 @@ describe("generateHooks", () => {
   });
 });
 
+describe("logger meta validation (executed)", () => {
+  let projectDir: string;
+  let differentDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "oh-my-harness-meta-"));
+    differentDir = await mkdtemp(join(tmpdir(), "oh-my-harness-meta-cwd-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(differentDir, { recursive: true, force: true });
+  });
+
+  it("falls back to no-meta when caller passes invalid JSON for meta", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          {
+            id: "bad-meta",
+            matcher: "Bash",
+            inline:
+              '#!/bin/bash\nset -euo pipefail\nINPUT=$(cat)\n_log_event "allow" "" "this is not json"\nexit 0',
+          },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+    await execFileAsync("bash", ["-c", `echo '{}' | bash "${scriptPath}"`], {
+      cwd: differentDir,
+      env: { ...process.env },
+      timeout: 5000,
+    });
+
+    const eventsPath = join(projectDir, ".omh/state/events.jsonl");
+    const raw = await readFile(eventsPath, "utf8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.decision).toBe("allow");
+    expect(parsed.meta).toBeUndefined();
+  });
+
+  it("includes valid JSON meta when caller passes a serialized object", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          {
+            id: "good-meta",
+            matcher: "Bash",
+            inline:
+              '#!/bin/bash\nset -euo pipefail\nINPUT=$(cat)\n_log_event "allow" "" \'{"k":"v"}\'\nexit 0',
+          },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+    await execFileAsync("bash", ["-c", `echo '{}' | bash "${scriptPath}"`], {
+      cwd: differentDir,
+      env: { ...process.env },
+      timeout: 5000,
+    });
+
+    const raw = await readFile(join(projectDir, ".omh/state/events.jsonl"), "utf8");
+    const parsed = JSON.parse(raw.trim().split("\n").filter(Boolean)[0]);
+    expect(parsed.meta).toEqual({ k: "v" });
+  });
+});
+
 describe("wrapWithLogger", () => {
   it("inserts logger after INPUT=$(cat)", () => {
     const script = "#!/bin/bash\nset -euo pipefail\nINPUT=$(cat)\nexit 0";

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -99,10 +99,10 @@ describe("generateHooks", () => {
     expect(result.hooksConfig).toHaveProperty("PostToolUse");
 
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/command-guard.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/command-guard.sh")}'` }] },
     ]);
     expect(result.hooksConfig["PostToolUse"]).toEqual([
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/lint-on-save.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/lint-on-save.sh")}'` }] },
     ]);
   });
 
@@ -172,8 +172,8 @@ describe("generateHooks", () => {
 
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/guard-bash.sh")}"` }] },
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/guard-edit.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/guard-bash.sh")}'` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/guard-edit.sh")}'` }] },
     ]);
   });
 
@@ -194,7 +194,7 @@ describe("generateHooks", () => {
     const scriptPath = join(projectDir, `.omh/hooks/${safeId}.sh`);
     expect(result.generatedFiles).toContain(scriptPath);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, `.omh/hooks/${safeId}.sh`)}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash '${join(projectDir, `.omh/hooks/${safeId}.sh`)}'` }] },
     ]);
     // Ensure no file was written outside the hooks dir
     const content = await readFile(scriptPath, "utf8");
@@ -221,8 +221,8 @@ describe("generateHooks", () => {
     expect(result.generatedFiles).toContain(file1);
     expect(result.generatedFiles).toContain(file2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/hook.sh")}"` }] },
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/hook-1.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/hook.sh")}'` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/hook-1.sh")}'` }] },
     ]);
   });
 
@@ -318,8 +318,8 @@ describe("generateHooks", () => {
     // Check hooksConfig contains both hooks
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
     const commands = result.hooksConfig["PreToolUse"].map(h => h.hooks[0].command);
-    expect(commands).toContain(`bash "${join(projectDir, ".omh/hooks/myhook.sh")}"`);
-    expect(commands).toContain(`bash "${join(projectDir, ".omh/hooks/myhook-1.sh")}"`);
+    expect(commands).toContain(`bash '${join(projectDir, ".omh/hooks/myhook.sh")}'`);
+    expect(commands).toContain(`bash '${join(projectDir, ".omh/hooks/myhook-1.sh")}'`);
 
   });
 
@@ -343,11 +343,128 @@ describe("generateHooks", () => {
     expect(result.generatedFiles).toContain(file1);
     expect(result.generatedFiles).toContain(file2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/myhook.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/myhook.sh")}'` }] },
     ]);
     expect(result.hooksConfig["PostToolUse"]).toEqual([
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/myhook-1.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash '${join(projectDir, ".omh/hooks/myhook-1.sh")}'` }] },
     ]);
+  });
+});
+
+describe("shell injection defense", () => {
+  let projectDir: string;
+  let differentDir: string;
+
+  beforeEach(async () => {
+    // mkdtemp template ends with random suffix; embed shell metacharacter ($)
+    // in a real subdirectory so the rendered bash script must escape it.
+    const base = await mkdtemp(join(tmpdir(), "omh-shellesc-"));
+    projectDir = join(base, "with$dollar dir");
+    await (await import("node:fs/promises")).mkdir(projectDir, { recursive: true });
+    differentDir = await mkdtemp(join(tmpdir(), "omh-shellesc-cwd-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(differentDir, { recursive: true, force: true });
+  });
+
+  it("logger writes to the literal path even when projectDir contains $ and spaces", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          {
+            id: "esc-test",
+            matcher: "Bash",
+            inline:
+              '#!/bin/bash\nset -euo pipefail\n_log_event "allow" "ok"\nexit 0',
+          },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+
+    // Invoke bash directly with scriptPath as argv to avoid the shell
+    // re-expanding $dollar in our test driver. The defended path is the
+    // generated script body, not how we run it.
+    const { spawn } = await import("node:child_process");
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("bash", [scriptPath], {
+        cwd: differentDir,
+        env: { ...process.env, dollar: "EXPANDED-WRONG" },
+      });
+      child.stdin.end();
+      let stderr = "";
+      child.stderr.on("data", (b: Buffer) => {
+        stderr += b.toString();
+      });
+      child.on("close", (code) =>
+        code === 0 ? resolve() : reject(new Error(`exit ${code}: ${stderr}`)),
+      );
+    });
+
+    // events.jsonl must land under the literal projectDir, not at a path
+    // produced by shell expansion of $dollar.
+    const eventsPath = join(projectDir, ".omh/state/events.jsonl");
+    await expect(access(eventsPath)).resolves.toBeUndefined();
+  });
+
+  it("emits hooksConfig commands wrapped in single quotes", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [{ id: "g", matcher: "Bash", inline: "#!/bin/bash\nexit 0" }],
+        postToolUse: [],
+      },
+    });
+    const result = await generateHooks({ projectDir, config });
+    const cmd = result.hooksConfig.PreToolUse[0].hooks[0].command;
+    expect(cmd).toMatch(/^bash '.*'$/);
+    expect(cmd).toContain("with$dollar");
+  });
+});
+
+describe("manifest validation (path traversal defense)", () => {
+  let projectDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "omh-manifest-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+  });
+
+  it("ignores manifest entries containing path separators or '..'", async () => {
+    const { mkdir, writeFile } = await import("node:fs/promises");
+    await mkdir(join(projectDir, ".omh"), { recursive: true });
+    // Pre-seed a manifest with a malicious traversal entry; if cleanup
+    // honored it, we'd try to unlink ../etc-victim.txt.
+    await writeFile(
+      join(projectDir, ".omh/manifest.json"),
+      JSON.stringify({
+        generatedAt: "x",
+        hooks: [
+          "../etc-victim.txt",
+          "../../passwd",
+          "/abs/path.sh",
+          "valid-name.sh",
+        ],
+      }),
+      "utf8",
+    );
+    // Place a sentinel file outside the hooks dir that the malicious entry
+    // would resolve to (relative path joined with hooksDir).
+    const sentinel = join(projectDir, "etc-victim.txt");
+    await writeFile(sentinel, "do-not-delete", "utf8");
+
+    // Now run a fresh sync with no hooks. The cleanup pass must NOT touch
+    // the sentinel file because the manifest entry should be filtered out.
+    await generateHooks({ projectDir, config: makeMergedConfig() });
+
+    await expect(access(sentinel)).resolves.toBeUndefined();
   });
 });
 
@@ -489,7 +606,7 @@ describe("wrapWithLogger", () => {
   it("produces absolute _OMH_STATE_DIR when projectDir is provided", () => {
     const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
     const result = wrapWithLogger(script, "PreToolUse", "/tmp/my-project");
-    expect(result).toContain('_OMH_STATE_DIR="/tmp/my-project/.omh/state"');
+    expect(result).toContain(`_OMH_STATE_DIR='/tmp/my-project/.omh/state'`);
   });
 
   it("EXIT trap logs 'error' instead of 'allow' when script exits non-zero", () => {
@@ -504,7 +621,7 @@ describe("wrapWithLogger", () => {
   it("keeps relative _OMH_STATE_DIR when projectDir is omitted", () => {
     const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
     const result = wrapWithLogger(script, "PreToolUse");
-    expect(result).toContain('_OMH_STATE_DIR=".omh/state"');
+    expect(result).toContain(`_OMH_STATE_DIR='.omh/state'`);
   });
 });
 

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -57,7 +57,7 @@ describe("generateHooks", () => {
     const result = await generateHooks({ projectDir, config });
 
     expect(result.generatedFiles).toHaveLength(1);
-    const scriptPath = join(projectDir, ".claude/hooks/command-guard.sh");
+    const scriptPath = join(projectDir, ".omh/hooks/command-guard.sh");
     const content = await readFile(scriptPath, "utf8");
     expect(content).toContain("#!/bin/bash");
     expect(content).toContain("exit 0");
@@ -75,7 +75,7 @@ describe("generateHooks", () => {
 
     await generateHooks({ projectDir, config });
 
-    const scriptPath = join(projectDir, ".claude/hooks/command-guard.sh");
+    const scriptPath = join(projectDir, ".omh/hooks/command-guard.sh");
     const fileStat = await stat(scriptPath);
     // Check owner execute bit (0o100)
     expect(fileStat.mode & 0o111).toBeGreaterThan(0);
@@ -99,10 +99,10 @@ describe("generateHooks", () => {
     expect(result.hooksConfig).toHaveProperty("PostToolUse");
 
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/command-guard.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/command-guard.sh")}"` }] },
     ]);
     expect(result.hooksConfig["PostToolUse"]).toEqual([
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/lint-on-save.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/lint-on-save.sh")}"` }] },
     ]);
   });
 
@@ -118,7 +118,7 @@ describe("generateHooks", () => {
     });
 
     const result = await generateHooks({ projectDir, config: makeMergedConfig() });
-    const manifestPath = join(projectDir, ".claude/hooks/oh-my-harness-manifest.json");
+    const manifestPath = join(projectDir, ".omh/manifest.json");
     const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
 
     expect(result).toEqual({ hooksConfig: {}, generatedFiles: [] });
@@ -126,10 +126,10 @@ describe("generateHooks", () => {
   });
 
   it("throws when an existing hooks manifest cannot be parsed", async () => {
-    const hooksDir = join(projectDir, ".claude/hooks");
+    const omhDir = join(projectDir, ".omh");
     const { mkdir, writeFile } = await import("node:fs/promises");
-    await mkdir(hooksDir, { recursive: true });
-    await writeFile(join(hooksDir, "oh-my-harness-manifest.json"), "{not-json", "utf8");
+    await mkdir(omhDir, { recursive: true });
+    await writeFile(join(omhDir, "manifest.json"), "{not-json", "utf8");
 
     await expect(generateHooks({ projectDir, config: makeMergedConfig() })).rejects.toThrow();
   });
@@ -148,7 +148,7 @@ describe("generateHooks", () => {
 
     await generateHooks({ projectDir, config });
 
-    const manifestPath = join(projectDir, ".claude/hooks/oh-my-harness-manifest.json");
+    const manifestPath = join(projectDir, ".omh/manifest.json");
     const manifestContent = await readFile(manifestPath, "utf8");
     const manifest = JSON.parse(manifestContent);
 
@@ -172,8 +172,8 @@ describe("generateHooks", () => {
 
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/guard-bash.sh")}"` }] },
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/guard-edit.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/guard-bash.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/guard-edit.sh")}"` }] },
     ]);
   });
 
@@ -191,10 +191,10 @@ describe("generateHooks", () => {
 
     // Sanitized id: only alphanumeric, hyphens, underscores remain
     const safeId = "etcpasswd";
-    const scriptPath = join(projectDir, `.claude/hooks/${safeId}.sh`);
+    const scriptPath = join(projectDir, `.omh/hooks/${safeId}.sh`);
     expect(result.generatedFiles).toContain(scriptPath);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, `.claude/hooks/${safeId}.sh`)}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, `.omh/hooks/${safeId}.sh`)}"` }] },
     ]);
     // Ensure no file was written outside the hooks dir
     const content = await readFile(scriptPath, "utf8");
@@ -215,14 +215,14 @@ describe("generateHooks", () => {
 
     const result = await generateHooks({ projectDir, config });
 
-    const file1 = join(projectDir, ".claude/hooks/hook.sh");
-    const file2 = join(projectDir, ".claude/hooks/hook-1.sh");
+    const file1 = join(projectDir, ".omh/hooks/hook.sh");
+    const file2 = join(projectDir, ".omh/hooks/hook-1.sh");
 
     expect(result.generatedFiles).toContain(file1);
     expect(result.generatedFiles).toContain(file2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/hook.sh")}"` }] },
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/hook-1.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/hook.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/hook-1.sh")}"` }] },
     ]);
   });
 
@@ -258,10 +258,10 @@ describe("generateHooks", () => {
 
     expect(result.generatedFiles).toHaveLength(2);
     expect(result.generatedFiles).toContain(
-      join(projectDir, ".claude/hooks/command-guard.sh")
+      join(projectDir, ".omh/hooks/command-guard.sh")
     );
     expect(result.generatedFiles).toContain(
-      join(projectDir, ".claude/hooks/lint-on-save.sh")
+      join(projectDir, ".omh/hooks/lint-on-save.sh")
     );
   });
 
@@ -277,7 +277,7 @@ describe("generateHooks", () => {
 
     await generateHooks({ projectDir, config });
 
-    const scriptPath = join(projectDir, ".claude/hooks/command-guard.sh");
+    const scriptPath = join(projectDir, ".omh/hooks/command-guard.sh");
     const content = await readFile(scriptPath, "utf8");
     expect(content).toContain("_OMH_STATE_DIR");
     expect(content).toContain("_log_event");
@@ -302,8 +302,8 @@ describe("generateHooks", () => {
     expect(result.generatedFiles).toHaveLength(2);
 
     // Check that files exist and have different names
-    const file1 = join(projectDir, ".claude/hooks/myhook.sh");
-    const file2 = join(projectDir, ".claude/hooks/myhook-1.sh");
+    const file1 = join(projectDir, ".omh/hooks/myhook.sh");
+    const file2 = join(projectDir, ".omh/hooks/myhook-1.sh");
 
     const content1 = await readFile(file1, "utf8");
     const content2 = await readFile(file2, "utf8");
@@ -318,8 +318,8 @@ describe("generateHooks", () => {
     // Check hooksConfig contains both hooks
     expect(result.hooksConfig["PreToolUse"]).toHaveLength(2);
     const commands = result.hooksConfig["PreToolUse"].map(h => h.hooks[0].command);
-    expect(commands).toContain(`bash "${join(projectDir, ".claude/hooks/myhook.sh")}"`);
-    expect(commands).toContain(`bash "${join(projectDir, ".claude/hooks/myhook-1.sh")}"`);
+    expect(commands).toContain(`bash "${join(projectDir, ".omh/hooks/myhook.sh")}"`);
+    expect(commands).toContain(`bash "${join(projectDir, ".omh/hooks/myhook-1.sh")}"`);
 
   });
 
@@ -337,16 +337,16 @@ describe("generateHooks", () => {
 
     const result = await generateHooks({ projectDir, config });
 
-    const file1 = join(projectDir, ".claude/hooks/myhook.sh");
-    const file2 = join(projectDir, ".claude/hooks/myhook-1.sh");
+    const file1 = join(projectDir, ".omh/hooks/myhook.sh");
+    const file2 = join(projectDir, ".omh/hooks/myhook-1.sh");
 
     expect(result.generatedFiles).toContain(file1);
     expect(result.generatedFiles).toContain(file2);
     expect(result.hooksConfig["PreToolUse"]).toEqual([
-      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/myhook.sh")}"` }] },
+      { matcher: "Bash", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/myhook.sh")}"` }] },
     ]);
     expect(result.hooksConfig["PostToolUse"]).toEqual([
-      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".claude/hooks/myhook-1.sh")}"` }] },
+      { matcher: "Edit|Write", hooks: [{ type: "command", command: `bash "${join(projectDir, ".omh/hooks/myhook-1.sh")}"` }] },
     ]);
   });
 });
@@ -414,7 +414,7 @@ describe("wrapWithLogger", () => {
   it("produces absolute _OMH_STATE_DIR when projectDir is provided", () => {
     const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
     const result = wrapWithLogger(script, "PreToolUse", "/tmp/my-project");
-    expect(result).toContain('_OMH_STATE_DIR="/tmp/my-project/.claude/hooks/.state"');
+    expect(result).toContain('_OMH_STATE_DIR="/tmp/my-project/.omh/state"');
   });
 
   it("EXIT trap logs 'error' instead of 'allow' when script exits non-zero", () => {
@@ -429,7 +429,7 @@ describe("wrapWithLogger", () => {
   it("keeps relative _OMH_STATE_DIR when projectDir is omitted", () => {
     const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
     const result = wrapWithLogger(script, "PreToolUse");
-    expect(result).toContain('_OMH_STATE_DIR=".claude/hooks/.state"');
+    expect(result).toContain('_OMH_STATE_DIR=".omh/state"');
   });
 });
 
@@ -457,8 +457,8 @@ describe("generateHooks — stale hook cleanup on sync", () => {
     });
     await generateHooks({ projectDir, config: configBefore });
 
-    const tddScript = join(projectDir, ".claude/hooks/tdd-guard.sh");
-    const branchScript = join(projectDir, ".claude/hooks/branch-guard.sh");
+    const tddScript = join(projectDir, ".omh/hooks/tdd-guard.sh");
+    const branchScript = join(projectDir, ".omh/hooks/branch-guard.sh");
 
     // Verify both files exist
     await expect(stat(tddScript)).resolves.toBeDefined();
@@ -492,7 +492,7 @@ describe("generateHooks — stale hook cleanup on sync", () => {
     });
     await generateHooks({ projectDir, config: configBefore });
 
-    const tddScript = join(projectDir, ".claude/hooks/tdd-guard.sh");
+    const tddScript = join(projectDir, ".omh/hooks/tdd-guard.sh");
     await expect(stat(tddScript)).resolves.toBeDefined();
 
     // Second sync: no hooks
@@ -665,7 +665,7 @@ describe("generateHooks — cwd-independence", () => {
     });
 
     // events.jsonl should be under projectDir, NOT under differentDir
-    const eventsPath = join(projectDir, ".claude/hooks/.state/events.jsonl");
+    const eventsPath = join(projectDir, ".omh/state/events.jsonl");
     await expect(access(eventsPath)).resolves.toBeUndefined();
 
     const events = await readFile(eventsPath, "utf8");
@@ -673,7 +673,7 @@ describe("generateHooks — cwd-independence", () => {
     expect(events).toContain('"reason":"test"');
 
     // Verify nothing was written under differentDir
-    const wrongEventsPath = join(differentDir, ".claude/hooks/.state/events.jsonl");
+    const wrongEventsPath = join(differentDir, ".omh/state/events.jsonl");
     await expect(access(wrongEventsPath)).rejects.toThrow();
   });
 });

--- a/tests/unit/hooks-generator.test.ts
+++ b/tests/unit/hooks-generator.test.ts
@@ -468,6 +468,110 @@ describe("manifest validation (path traversal defense)", () => {
   });
 });
 
+describe("logger JSON escaping (executed)", () => {
+  let projectDir: string;
+  let differentDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "omh-jsonesc-"));
+    differentDir = await mkdtemp(join(tmpdir(), "omh-jsonesc-cwd-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(differentDir, { recursive: true, force: true });
+  });
+
+  it("escapes quotes/newlines/backslashes in reason via jq", async () => {
+    // Pre-jq impl injected $reason via printf %s and broke JSONL when the
+    // reason contained these characters; event-logger.ts then silently
+    // dropped the line, losing the event entirely.
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          {
+            id: "hard-reason",
+            matcher: "Bash",
+            inline:
+              '#!/bin/bash\nset -euo pipefail\nREASON=$\'He said "hi"\\nand \\\\left\'\n_log_event "block" "$REASON"\nexit 0',
+          },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+    const { spawn } = await import("node:child_process");
+    await new Promise<void>((resolve, reject) => {
+      const child = spawn("bash", [scriptPath], { cwd: differentDir });
+      child.stdin.end();
+      child.on("close", (code) =>
+        code === 0 ? resolve() : reject(new Error(`exit ${code}`)),
+      );
+    });
+
+    const raw = await readFile(join(projectDir, ".omh/state/events.jsonl"), "utf8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.decision).toBe("block");
+    expect(parsed.reason).toBe('He said "hi"\nand \\left');
+  });
+});
+
+describe("_emit_decision (executed)", () => {
+  let projectDir: string;
+  let differentDir: string;
+
+  beforeEach(async () => {
+    projectDir = await mkdtemp(join(tmpdir(), "omh-emitdec-"));
+    differentDir = await mkdtemp(join(tmpdir(), "omh-emitdec-cwd-"));
+  });
+
+  afterEach(async () => {
+    await rm(projectDir, { recursive: true, force: true });
+    await rm(differentDir, { recursive: true, force: true });
+  });
+
+  it("emits valid JSON decision even when reason has quotes/newlines", async () => {
+    const config = makeMergedConfig({
+      hooks: {
+        preToolUse: [
+          {
+            id: "decision-test",
+            matcher: "Bash",
+            inline:
+              '#!/bin/bash\nset -euo pipefail\nREASON=$\'O\\\'Brien said "no"\\nrejected\'\n_emit_decision "block" "$REASON"\nexit 0',
+          },
+        ],
+        postToolUse: [],
+      },
+    });
+
+    const result = await generateHooks({ projectDir, config });
+    const scriptPath = result.generatedFiles[0];
+    const { spawn } = await import("node:child_process");
+    const stdoutP = new Promise<string>((resolve, reject) => {
+      const child = spawn("bash", [scriptPath], { cwd: differentDir });
+      let stdout = "";
+      child.stdout.on("data", (b: Buffer) => {
+        stdout += b.toString();
+      });
+      child.stdin.end();
+      child.on("close", (code) =>
+        code === 0 ? resolve(stdout) : reject(new Error(`exit ${code}`)),
+      );
+    });
+    const stdout = await stdoutP;
+
+    // Whatever the script printed must be parseable JSON with the right fields.
+    const parsed = JSON.parse(stdout.trim());
+    expect(parsed.decision).toBe("block");
+    expect(parsed.reason).toBe(`O'Brien said "no"\nrejected`);
+  });
+});
+
 describe("logger meta validation (executed)", () => {
   let projectDir: string;
   let differentDir: string;
@@ -593,7 +697,9 @@ describe("wrapWithLogger", () => {
   it("logger snippet includes event field in JSON output", () => {
     const script = "#!/bin/bash\nINPUT=$(cat)\nexit 0";
     const result = wrapWithLogger(script);
-    expect(result).toContain('"event"');
+    // jq-based assembly: the filter must reference the event field.
+    expect(result).toMatch(/event:\$event/);
+    expect(result).toContain("--arg event");
   });
 
   it("handles #!/usr/bin/env bash shebang", () => {

--- a/tests/unit/sql-guard.test.ts
+++ b/tests/unit/sql-guard.test.ts
@@ -36,7 +36,10 @@ describe("sqlGuard block", () => {
     expect(sqlGuard.template).toContain("tr '[:upper:]' '[:lower:]'");
   });
 
-  it("does not contain _log_event wrapper", () => {
-    expect(sqlGuard.template).not.toContain("_log_event");
+  it("logs the block via _log_event for omh stats parity with other guards", () => {
+    // sql-guard previously omitted _log_event so its blocks were invisible
+    // in events.jsonl / omh stats. Now consistent with all other guards.
+    expect(sqlGuard.template).toContain('_log_event "block" "$REASON"');
+    expect(sqlGuard.template).toContain('_emit_decision "block" "$REASON"');
   });
 });

--- a/tests/unit/state-migration.test.ts
+++ b/tests/unit/state-migration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { migrateLegacyState } from "../../src/utils/state-migration.js";
+
+describe("migrateLegacyState", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-mig-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty report when legacy state directory does not exist", async () => {
+    const report = await migrateLegacyState(tmpDir);
+    expect(report.migrated).toEqual([]);
+  });
+
+  it("moves events.jsonl to .omh/state/events.jsonl", async () => {
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(legacyState, { recursive: true });
+    const sample = '{"ts":"2026-01-01T00:00:00Z","event":"PreToolUse","hook":"x.sh","decision":"allow"}\n';
+    await fs.writeFile(path.join(legacyState, "events.jsonl"), sample, "utf8");
+
+    await migrateLegacyState(tmpDir);
+
+    const moved = await fs.readFile(path.join(tmpDir, ".omh/state/events.jsonl"), "utf8");
+    expect(moved).toContain('"hook":"x.sh"');
+  });
+
+  it("renames edit-history.json to tdd-edits.json", async () => {
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(legacyState, { recursive: true });
+    await fs.writeFile(
+      path.join(legacyState, "edit-history.json"),
+      JSON.stringify({ edits: ["foo.test.ts"] }),
+      "utf8",
+    );
+
+    await migrateLegacyState(tmpDir);
+
+    const moved = await fs.readFile(path.join(tmpDir, ".omh/state/tdd-edits.json"), "utf8");
+    expect(JSON.parse(moved)).toEqual({ edits: ["foo.test.ts"] });
+  });
+
+  it("absorbs config-audit.log into events.jsonl as ConfigChange events", async () => {
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(legacyState, { recursive: true });
+    const audit =
+      '{"ts":"2026-01-01T00:00:00Z","source":"user_settings","file":"/u/.claude/settings.json"}\n' +
+      '{"ts":"2026-01-02T00:00:00Z","source":"skills","file":"/u/.claude/skills/x.md"}\n';
+    await fs.writeFile(path.join(legacyState, "config-audit.log"), audit, "utf8");
+
+    await migrateLegacyState(tmpDir);
+
+    const events = await fs.readFile(path.join(tmpDir, ".omh/state/events.jsonl"), "utf8");
+    const lines = events.trim().split("\n").map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(2);
+    expect(lines[0].event).toBe("ConfigChange");
+    expect(lines[0].decision).toBe("allow");
+    expect(lines[0].hook).toBe("catalog-config-audit.sh");
+    expect(lines[0].meta).toEqual({ source: "user_settings", file: "/u/.claude/settings.json" });
+    expect(lines[1].meta.source).toBe("skills");
+  });
+
+  it("does not overwrite an existing .omh/state/events.jsonl", async () => {
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    const newState = path.join(tmpDir, ".omh/state");
+    await fs.mkdir(legacyState, { recursive: true });
+    await fs.mkdir(newState, { recursive: true });
+    await fs.writeFile(path.join(legacyState, "events.jsonl"), "OLD\n", "utf8");
+    await fs.writeFile(path.join(newState, "events.jsonl"), "NEW\n", "utf8");
+
+    await migrateLegacyState(tmpDir);
+
+    const content = await fs.readFile(path.join(newState, "events.jsonl"), "utf8");
+    expect(content).toBe("NEW\n");
+  });
+
+  it("moves the manifest from .claude/hooks to .omh/manifest.json", async () => {
+    await fs.mkdir(path.join(tmpDir, ".claude/hooks/.state"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, ".claude/hooks/oh-my-harness-manifest.json"),
+      JSON.stringify({ generatedAt: "x", hooks: ["a.sh"] }),
+      "utf8",
+    );
+
+    await migrateLegacyState(tmpDir);
+
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(tmpDir, ".omh/manifest.json"), "utf8"),
+    );
+    expect(manifest.hooks).toEqual(["a.sh"]);
+  });
+
+  it("is idempotent: running twice does not duplicate events", async () => {
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(legacyState, { recursive: true });
+    await fs.writeFile(
+      path.join(legacyState, "config-audit.log"),
+      '{"ts":"2026-01-01T00:00:00Z","source":"x","file":"y"}\n',
+      "utf8",
+    );
+
+    await migrateLegacyState(tmpDir);
+    // Second run: legacy log was unlinked → no-op
+    await migrateLegacyState(tmpDir);
+
+    const events = await fs.readFile(path.join(tmpDir, ".omh/state/events.jsonl"), "utf8");
+    expect(events.trim().split("\n")).toHaveLength(1);
+  });
+});

--- a/tests/unit/state-migration.test.ts
+++ b/tests/unit/state-migration.test.ts
@@ -81,6 +81,37 @@ describe("migrateLegacyState", () => {
     expect(content).toBe("NEW\n");
   });
 
+  it("preserves a legacy file when migration was skipped (data-loss guard)", async () => {
+    // Both legacy and new exist with different content. Copy is skipped.
+    // Legacy MUST still exist after migration so user can recover its content.
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    const newState = path.join(tmpDir, ".omh/state");
+    await fs.mkdir(legacyState, { recursive: true });
+    await fs.mkdir(newState, { recursive: true });
+    await fs.writeFile(path.join(legacyState, "events.jsonl"), "OLD\n", "utf8");
+    await fs.writeFile(path.join(newState, "events.jsonl"), "NEW\n", "utf8");
+    await fs.writeFile(
+      path.join(legacyState, "edit-history.json"),
+      JSON.stringify({ edits: ["legacy-only.test.ts"] }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(newState, "tdd-edits.json"),
+      JSON.stringify({ edits: [] }),
+      "utf8",
+    );
+
+    await migrateLegacyState(tmpDir);
+
+    // Legacy events.jsonl preserved (skipped path must not delete data)
+    const legacyEvents = await fs.readFile(path.join(legacyState, "events.jsonl"), "utf8");
+    expect(legacyEvents).toBe("OLD\n");
+
+    // Legacy edit-history preserved as well
+    const legacyTdd = await fs.readFile(path.join(legacyState, "edit-history.json"), "utf8");
+    expect(JSON.parse(legacyTdd).edits).toEqual(["legacy-only.test.ts"]);
+  });
+
   it("moves the manifest from .claude/hooks to .omh/manifest.json", async () => {
     await fs.mkdir(path.join(tmpDir, ".claude/hooks/.state"), { recursive: true });
     await fs.writeFile(

--- a/tests/unit/state-migration.test.ts
+++ b/tests/unit/state-migration.test.ts
@@ -128,6 +128,55 @@ describe("migrateLegacyState", () => {
     expect(manifest.hooks).toEqual(["a.sh"]);
   });
 
+  it("migrates a legacy manifest even when legacy .state directory is absent", async () => {
+    // User synced but no hooks ever fired → no .state dir, but manifest exists.
+    await fs.mkdir(path.join(tmpDir, ".claude/hooks"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, ".claude/hooks/oh-my-harness-manifest.json"),
+      JSON.stringify({ generatedAt: "x", hooks: ["foo.sh"] }),
+      "utf8",
+    );
+
+    const report = await migrateLegacyState(tmpDir);
+
+    const moved = JSON.parse(
+      await fs.readFile(path.join(tmpDir, ".omh/manifest.json"), "utf8"),
+    );
+    expect(moved.hooks).toEqual(["foo.sh"]);
+    expect(report.migrated).toContain("manifest.json");
+  });
+
+  it("inserts a separator newline if existing events.jsonl is missing trailing newline", async () => {
+    const newState = path.join(tmpDir, ".omh/state");
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(newState, { recursive: true });
+    await fs.mkdir(legacyState, { recursive: true });
+    // Pre-existing newEvents WITHOUT trailing newline (corrupted/edited state)
+    await fs.writeFile(
+      path.join(newState, "events.jsonl"),
+      '{"ts":"2026-01-01T00:00:00Z","event":"PreToolUse","hook":"x.sh","decision":"allow"}',
+      "utf8",
+    );
+    // Legacy config-audit.log to be absorbed
+    await fs.writeFile(
+      path.join(legacyState, "config-audit.log"),
+      '{"ts":"2026-01-02T00:00:00Z","source":"x","file":"y"}\n',
+      "utf8",
+    );
+
+    await migrateLegacyState(tmpDir);
+
+    const events = await fs.readFile(path.join(newState, "events.jsonl"), "utf8");
+    // Every non-empty line MUST be valid JSON (no glued records)
+    for (const line of events.split("\n")) {
+      if (!line.trim()) continue;
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+    // Two distinct entries
+    const entries = events.split("\n").filter((l) => l.trim());
+    expect(entries).toHaveLength(2);
+  });
+
   it("is idempotent: running twice does not duplicate events", async () => {
     const legacyState = path.join(tmpDir, ".claude/hooks/.state");
     await fs.mkdir(legacyState, { recursive: true });

--- a/tests/unit/state-migration.test.ts
+++ b/tests/unit/state-migration.test.ts
@@ -177,6 +177,34 @@ describe("migrateLegacyState", () => {
     expect(entries).toHaveLength(2);
   });
 
+  it("skips non-object JSON lines in config-audit.log instead of crashing", async () => {
+    // JSON.parse("null") succeeds with null; .ts access on null throws.
+    // A single bad line must NOT abort the whole migration.
+    const legacyState = path.join(tmpDir, ".claude/hooks/.state");
+    await fs.mkdir(legacyState, { recursive: true });
+    await fs.writeFile(
+      path.join(legacyState, "config-audit.log"),
+      [
+        "null",
+        "42",
+        "[1, 2]",
+        '"a string"',
+        '{"ts":"2026-01-01T00:00:00Z","source":"x","file":"y"}',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await expect(migrateLegacyState(tmpDir)).resolves.toBeDefined();
+
+    const events = await fs.readFile(path.join(tmpDir, ".omh/state/events.jsonl"), "utf8");
+    const entries = events.trim().split("\n").filter(Boolean).map((l) => JSON.parse(l));
+    // Only the well-formed audit object survived; the four non-object lines
+    // were skipped without aborting the run.
+    expect(entries).toHaveLength(1);
+    expect(entries[0].meta.source).toBe("x");
+  });
+
   it("is idempotent: running twice does not duplicate events", async () => {
     const legacyState = path.join(tmpDir, ".claude/hooks/.state");
     await fs.mkdir(legacyState, { recursive: true });

--- a/tests/unit/stats-data.test.ts
+++ b/tests/unit/stats-data.test.ts
@@ -241,7 +241,7 @@ afterEach(async () => {
 describe("loadStatsData", () => {
   it("events.jsonl + harness.yaml 통합 로드", async () => {
     // Write events.jsonl
-    const stateDir = path.join(tmpDir, ".claude/hooks/.state");
+    const stateDir = path.join(tmpDir, ".omh/state");
     await fs.mkdir(stateDir, { recursive: true });
     const events: HookEvent[] = [
       { ts: "2024-01-01T10:00:00.000Z", event: "PreToolUse", hook: "catalog-command-guard.sh", decision: "block", reason: "blocked" },


### PR DESCRIPTION
## Summary

- Adds **Codex CLI** support: `AGENTS.md` + `.codex/hooks.json` + `.codex/config.toml` (with `[features] codex_hooks = true`) emitter. Codex now uses the **same hook scripts** as Claude Code via a unified `.omh/hooks/` directory.
- Unifies all hook scripts and runtime state under **`.omh/`** — previously scattered under `.claude/hooks/.state/` with three different file formats (events.jsonl + config-audit.log + edit-history.json).
- Absorbs `config-audit.log` into the single `.omh/state/events.jsonl` with a meta object, so `omh stats` reads one file and the format is uniform.

### Why
Codex CLI now ships stable hook support with PreToolUse/PostToolUse/SessionStart/UserPromptSubmit/PermissionRequest/Stop and a matcher+command schema that mirrors Claude Code's. Rather than duplicate every script per-runtime, this PR centralizes scripts in `.omh/hooks/` and lets each runtime's settings file reference the same path.

### Project layout (after `omh init`)
\`\`\`
your-project/
├── CLAUDE.md           # Claude Code instructions
├── AGENTS.md           # Codex CLI instructions (same managed sections)
├── harness.yaml
├── .omh/
│   ├── hooks/*.sh      # single source of truth
│   ├── state/          # gitignored — events.jsonl + tdd-edits.json
│   └── manifest.json
├── .claude/settings.json   # references .omh/hooks/*.sh
└── .codex/
    ├── config.toml
    └── hooks.json      # references the same .omh/hooks/*.sh
\`\`\`

### Migration
\`generator.generate()\` runs a one-time migration on every sync that copies the legacy `.claude/hooks/.state/` forward without losing existing event history. \`config-audit.log\` lines are translated into ConfigChange events with the original `source`/`file` preserved as `meta`.

### Codex compatibility notes
- `Notification`, `WorktreeCreate`, `ConfigChange` events are skipped from Codex hooks.json (Codex doesn't have those events) — Claude side keeps them.
- `Edit|Write` matchers are normalized to `Edit|Write|apply_patch` so the same regex works in both runtimes.
- `[features] codex_hooks = true` is upserted between managed markers in `.codex/config.toml`, leaving any user MCP server config intact.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` — 952/952 passing
- [x] New unit tests for `agents-md`, `codex-config` (build/normalize/idempotency), `state-migration` (legacy → new, audit log absorption, idempotency)
- [x] `omh doctor` extended to verify AGENTS.md, `.codex/hooks.json`, `.codex/config.toml`, `.omh/hooks/*.sh` executability — 11/11 passing
- [x] All existing path-touching tests updated to expect `.omh/` layout
- [ ] Manual smoke test: run `omh init --preset typescript` in a fresh dir, verify both Claude & Codex configs reference the same `.omh/hooks/*.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * AGENTS.md 자동 생성기 및 Codex 구성(.codex/hooks.json, .codex/config.toml) 생성기 추가
  * 레거시 상태(.claude 등) 자동 마이그레이션 유틸 추가
  * writeManagedMarkdown 및 파일 유틸(pathExists, readFileOrDefault, endsWithNewline) 추가

* **변경사항**
  * 프로젝트 아티팩트 단일 .omh 레이아웃 통합(.omh/hooks, .omh/state, .omh/manifest, events.jsonl)
  * 이벤트 로깅에 선택적 meta 필드 추가 및 모든 로그 → events.jsonl 통합
  * 훅 경로/권한 검사·명령 문자열 정규화(단일 인용부호 사용) 및 결정/로깅 공통화(_emit_decision/_log_event)
  * doctor 명령에 AGENTS.md·Codex 검증 항목 추가, smol-toml 런타임 의존성 추가

* **테스트**
  * 통합·단위 테스트 전반이 .omh 레이아웃과 신규 동작에 맞춰 갱신됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->