### PR TITLE
feat: add version-check banner and `omh update` command

### DIFF
--- a/bin/oh-my-harness.ts
+++ b/bin/oh-my-harness.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env npx tsx
+import { createRequire } from "node:module";
 import { createCli } from "../src/cli/index.js";
+import { notifyIfUpdateAvailable } from "../src/cli/version-notifier.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { name: string; version: string };
+
+notifyIfUpdateAvailable({ name: pkg.name, version: pkg.version });
 
 const cli = createCli();
 cli.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "js-yaml": "^4.1.0",
         "react": "^19.2.4",
         "smol-toml": "^1.6.1",
+        "update-notifier": "^7.3.1",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -28,6 +29,7 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/react": "^19.2.14",
+        "@types/update-notifier": "^6.0.8",
         "ink-testing-library": "^4.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
@@ -879,6 +881,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@pnpm/config.env-replace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+      "integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+      "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "4.2.10"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
+    },
+    "node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "license": "ISC"
+    },
+    "node_modules/@pnpm/npm-conf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-3.0.2.tgz",
+      "integrity": "sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/config.env-replace": "^1.1.0",
+        "@pnpm/network.ca-file": "^1.0.1",
+        "config-chain": "^1.1.11"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -1240,6 +1283,13 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/configstore": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-6.0.2.tgz",
+      "integrity": "sha512-OS//b51j9uyR3zvwD04Kfs5kHpve2qalQ18JhY/ho3voGYUTPLEG90/ocfKPI48hyHH8T04f7KEEbK6Ue60oZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1279,6 +1329,167 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/update-notifier": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@types/update-notifier/-/update-notifier-6.0.8.tgz",
+      "integrity": "sha512-IlDFnfSVfYQD+cKIg63DEXn3RFmd7W1iYtKQsJodcHK9R1yr8aKbKaPKfBxzPpcHCq2DU8zUq4PIPmy19Thjfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/configstore": "*",
+        "boxen": "^7.1.1"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/boxen": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
+      "integrity": "sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.1",
+        "chalk": "^5.2.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/update-notifier/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/update-notifier/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1396,6 +1607,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -1451,6 +1671,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/atomically": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atomically/-/atomically-2.1.1.tgz",
+      "integrity": "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-fs": "^2.0.0",
+        "when-exit": "^2.1.4"
+      }
+    },
     "node_modules/auto-bind": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
@@ -1463,6 +1693,134 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boxen": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-8.0.1.tgz",
+      "integrity": "sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^8.0.0",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.21.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/boxen/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1471,6 +1829,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
+      "integrity": "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chai": {
@@ -1652,6 +2022,40 @@
         "node": ">=18"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/configstore": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
+      "integrity": "sha512-N4oog6YJWbR9kGyXvS7jEykLDXIE2C0ILYqNBZBp9iwiJpoCBWYsuAdW6PPFn6w06jjnC+3JstVvWHO4cZqvRg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "atomically": "^2.0.3",
+        "dot-prop": "^9.0.0",
+        "graceful-fs": "^4.2.11",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
@@ -1695,6 +2099,49 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/dot-prop": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-9.0.0.tgz",
+      "integrity": "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^4.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dot-prop/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1771,6 +2218,18 @@
         "@esbuild/win32-arm64": "0.27.4",
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
+      }
+    },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1860,6 +2319,27 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/global-directory": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
+      "integrity": "sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -1907,6 +2387,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/ink": {
@@ -2101,6 +2590,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-installed-globally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-1.0.0.tgz",
+      "integrity": "sha512-K55T22lfpQ63N4KEN57jZUAaAYqYHEe8veb/TycJRk9DdSCLLcovXz/mL6mOnhQaZsQGwPhuFopdQIlqGSEjiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "global-directory": "^4.0.1",
+        "is-path-inside": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-6.1.0.tgz",
+      "integrity": "sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2118,6 +2647,33 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/latest-version": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-9.0.0.tgz",
+      "integrity": "sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==",
+      "license": "MIT",
+      "dependencies": {
+        "package-json": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/loupe": {
@@ -2211,6 +2767,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-10.0.1.tgz",
+      "integrity": "sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==",
+      "license": "MIT",
+      "dependencies": {
+        "ky": "^1.2.0",
+        "registry-auth-token": "^5.0.2",
+        "registry-url": "^6.0.1",
+        "semver": "^7.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
@@ -2286,6 +2860,48 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "license": "ISC"
+    },
+    "node_modules/pupa": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+      "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -2308,6 +2924,33 @@
       },
       "peerDependencies": {
         "react": "^19.2.0"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.1.1.tgz",
+      "integrity": "sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@pnpm/npm-conf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+      "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "rc": "1.2.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2398,6 +3041,18 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -2550,6 +3205,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -2562,6 +3226,21 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/stubborn-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stubborn-fs/-/stubborn-fs-2.0.0.tgz",
+      "integrity": "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==",
+      "license": "MIT",
+      "dependencies": {
+        "stubborn-utils": "^1.0.1"
+      }
+    },
+    "node_modules/stubborn-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stubborn-utils/-/stubborn-utils-1.0.2.tgz",
+      "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
+      "license": "MIT"
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
@@ -2716,6 +3395,45 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/update-notifier": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-7.3.1.tgz",
+      "integrity": "sha512-+dwUY4L35XFYEzE+OAL3sarJdUioVovq+8f7lcIJ7wnmnYQV5UD1Y/lcwaMSyaQ6Bj3JMj1XSTjZbNLHn/19yA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boxen": "^8.0.1",
+        "chalk": "^5.3.0",
+        "configstore": "^7.0.0",
+        "is-in-ci": "^1.0.0",
+        "is-installed-globally": "^1.0.0",
+        "is-npm": "^6.0.0",
+        "latest-version": "^9.0.0",
+        "pupa": "^3.1.0",
+        "semver": "^7.6.3",
+        "xdg-basedir": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/yeoman/update-notifier?sponsor=1"
+      }
+    },
+    "node_modules/update-notifier/node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -2888,6 +3606,12 @@
         }
       }
     },
+    "node_modules/when-exit": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/when-exit/-/when-exit-2.1.5.tgz",
+      "integrity": "sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==",
+      "license": "MIT"
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3002,6 +3726,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-basedir": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
+      "integrity": "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors-cjs": {

--- a/package.json
+++ b/package.json
@@ -56,12 +56,14 @@
     "js-yaml": "^4.1.0",
     "react": "^19.2.4",
     "smol-toml": "^1.6.1",
+    "update-notifier": "^7.3.1",
     "zod": "^3.24.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
+    "@types/update-notifier": "^6.0.8",
     "ink-testing-library": "^4.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",

--- a/src/bin/oh-my-harness.ts
+++ b/src/bin/oh-my-harness.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import { createCli } from "../cli/index.js";
+import { notifyIfUpdateAvailable } from "../cli/version-notifier.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { name: string; version: string };
+
+notifyIfUpdateAvailable({ name: pkg.name, version: pkg.version });
 
 const cli = createCli();
 cli.parse(process.argv);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from "node:child_process";
+import { detectInstaller } from "../installer-detect.js";
+import { fetchLatestVersion } from "../version-checker.js";
+
+export interface UpdateOptions {
+  yes?: boolean;
+  dryRun?: boolean;
+}
+
+export interface UpdateDeps {
+  fetchLatest?: (name: string) => Promise<string | null>;
+  spawn?: (cmd: string, args: string[]) => { status: number };
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface UpdateResult {
+  exitCode: number;
+  ran: boolean;
+  command?: string;
+  latestVersion?: string;
+}
+
+const PKG_NAME = "oh-my-harness";
+
+function defaultSpawn(cmd: string, args: string[]): { status: number } {
+  const result = spawnSync(cmd, args, { stdio: "inherit" });
+  return { status: result.status ?? 1 };
+}
+
+export async function updateCommand(
+  currentVersion: string,
+  options: UpdateOptions = {},
+  deps: UpdateDeps = {},
+): Promise<UpdateResult> {
+  const fetchLatest = deps.fetchLatest ?? fetchLatestVersion;
+  const spawn = deps.spawn ?? defaultSpawn;
+  const env = deps.env ?? process.env;
+
+  console.log(`Current version: ${currentVersion}`);
+  console.log("Checking for updates…");
+
+  const latest = await fetchLatest(PKG_NAME);
+  if (!latest) {
+    console.log(
+      "Could not reach npm registry. Check your network and try again.",
+    );
+    return { exitCode: 1, ran: false };
+  }
+
+  if (latest === currentVersion) {
+    console.log(`Already up to date (${currentVersion}).`);
+    return { exitCode: 0, ran: false, latestVersion: latest };
+  }
+
+  console.log(`Update available: ${currentVersion} → ${latest}`);
+
+  const info = detectInstaller(env);
+  console.log(`Detected installer: ${info.installer}`);
+  if (info.notes) {
+    console.log(info.notes);
+  }
+  console.log(`Update command: ${info.updateCommand}`);
+
+  if (info.isEphemeral) {
+    console.log("Run the command above to install globally.");
+    return {
+      exitCode: 0,
+      ran: false,
+      command: info.updateCommand,
+      latestVersion: latest,
+    };
+  }
+
+  if (options.dryRun) {
+    return {
+      exitCode: 0,
+      ran: false,
+      command: info.updateCommand,
+      latestVersion: latest,
+    };
+  }
+
+  if (!options.yes && process.stdout.isTTY) {
+    const { confirm } = await import("@inquirer/prompts");
+    const proceed = await confirm({
+      message: `Run "${info.updateCommand}"?`,
+      default: true,
+    });
+    if (!proceed) {
+      console.log("Cancelled.");
+      return {
+        exitCode: 0,
+        ran: false,
+        command: info.updateCommand,
+        latestVersion: latest,
+      };
+    }
+  }
+
+  const [cmd, ...args] = info.updateCommand.split(" ");
+  const { status } = spawn(cmd, args);
+  if (status === 0) {
+    console.log(`Updated to ${latest}.`);
+  } else {
+    console.log(
+      `Update failed with exit code ${status}. Try running the command manually.`,
+    );
+  }
+
+  return {
+    exitCode: status,
+    ran: true,
+    command: info.updateCommand,
+    latestVersion: latest,
+  };
+}

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -80,7 +80,7 @@ export async function updateCommand(
     };
   }
 
-  if (!options.yes && process.stdout.isTTY) {
+  if (!options.yes && process.stdout.isTTY && process.stdin.isTTY) {
     const { confirm } = await import("@inquirer/prompts");
     const proceed = await confirm({
       message: `Run "${info.updateCommand}"?`,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,7 +2,7 @@ import { Command } from "commander";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-const pkg = require("../../package.json") as { version: string };
+const pkg = require("../../package.json") as { name: string; version: string };
 
 export function createCli(): Command {
   const program = new Command();
@@ -11,6 +11,19 @@ export function createCli(): Command {
     .name("oh-my-harness")
     .description("AI code agent harness configuration tool")
     .version(pkg.version);
+
+  program
+    .command("update")
+    .description("Check for and install the latest version of oh-my-harness")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("--dry-run", "Print the update command without running it")
+    .action(async (options: { yes?: boolean; dryRun?: boolean }) => {
+      const { updateCommand } = await import("./commands/update.js");
+      const result = await updateCommand(pkg.version, options);
+      if (result.exitCode !== 0) {
+        process.exitCode = result.exitCode;
+      }
+    });
 
   program
     .command("init [description...]")

--- a/src/cli/installer-detect.ts
+++ b/src/cli/installer-detect.ts
@@ -16,14 +16,30 @@ export interface InstallerInfo {
 
 const PKG = "oh-my-harness";
 
-const COMMANDS: Record<Exclude<Installer, "unknown">, string> = {
-  npm: `npm install -g ${PKG}@latest`,
-  pnpm: `pnpm add -g ${PKG}@latest`,
-  yarn: `yarn global add ${PKG}@latest`,
-  bun: `bun add -g ${PKG}@latest`,
-  volta: `volta install ${PKG}`,
-  npx: `npm install -g ${PKG}@latest`,
-};
+function parseYarnMajor(ua: string): number | null {
+  const match = ua.match(/yarn\/(\d+)/);
+  if (!match) return null;
+  const major = Number.parseInt(match[1], 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+function yarnInfo(ua: string): InstallerInfo {
+  const major = parseYarnMajor(ua);
+  if (major !== null && major >= 2) {
+    return {
+      installer: "yarn",
+      updateCommand: `yarn dlx ${PKG}@latest`,
+      isEphemeral: false,
+      notes:
+        "Yarn 2+ removed `yarn global` — `yarn dlx` runs the package on demand. Install globally with npm if you want a persistent binary.",
+    };
+  }
+  return {
+    installer: "yarn",
+    updateCommand: `yarn global add ${PKG}@latest`,
+    isEphemeral: false,
+  };
+}
 
 export function detectInstaller(
   env: NodeJS.ProcessEnv = process.env,
@@ -34,7 +50,7 @@ export function detectInstaller(
   if (ua.includes("npx") || execPath.includes("npx")) {
     return {
       installer: "npx",
-      updateCommand: COMMANDS.npx,
+      updateCommand: `npm install -g ${PKG}@latest`,
       isEphemeral: true,
       notes: "Detected npx run — install globally to keep updates persistent.",
     };
@@ -43,7 +59,7 @@ export function detectInstaller(
   if (env.VOLTA_HOME) {
     return {
       installer: "volta",
-      updateCommand: COMMANDS.volta,
+      updateCommand: `volta install ${PKG}`,
       isEphemeral: false,
     };
   }
@@ -51,35 +67,31 @@ export function detectInstaller(
   if (ua.includes("pnpm/")) {
     return {
       installer: "pnpm",
-      updateCommand: COMMANDS.pnpm,
+      updateCommand: `pnpm add -g ${PKG}@latest`,
       isEphemeral: false,
     };
   }
   if (ua.includes("yarn/")) {
-    return {
-      installer: "yarn",
-      updateCommand: COMMANDS.yarn,
-      isEphemeral: false,
-    };
+    return yarnInfo(ua);
   }
   if (ua.includes("bun/")) {
     return {
       installer: "bun",
-      updateCommand: COMMANDS.bun,
+      updateCommand: `bun add -g ${PKG}@latest`,
       isEphemeral: false,
     };
   }
   if (ua.includes("npm/")) {
     return {
       installer: "npm",
-      updateCommand: COMMANDS.npm,
+      updateCommand: `npm install -g ${PKG}@latest`,
       isEphemeral: false,
     };
   }
 
   return {
     installer: "npm",
-    updateCommand: COMMANDS.npm,
+    updateCommand: `npm install -g ${PKG}@latest`,
     isEphemeral: false,
   };
 }

--- a/src/cli/installer-detect.ts
+++ b/src/cli/installer-detect.ts
@@ -1,0 +1,85 @@
+export type Installer =
+  | "npm"
+  | "pnpm"
+  | "yarn"
+  | "bun"
+  | "volta"
+  | "npx"
+  | "unknown";
+
+export interface InstallerInfo {
+  installer: Installer;
+  updateCommand: string;
+  isEphemeral: boolean;
+  notes?: string;
+}
+
+const PKG = "oh-my-harness";
+
+const COMMANDS: Record<Exclude<Installer, "unknown">, string> = {
+  npm: `npm install -g ${PKG}@latest`,
+  pnpm: `pnpm add -g ${PKG}@latest`,
+  yarn: `yarn global add ${PKG}@latest`,
+  bun: `bun add -g ${PKG}@latest`,
+  volta: `volta install ${PKG}`,
+  npx: `npm install -g ${PKG}@latest`,
+};
+
+export function detectInstaller(
+  env: NodeJS.ProcessEnv = process.env,
+): InstallerInfo {
+  const ua = env.npm_config_user_agent ?? "";
+  const execPath = env.npm_execpath ?? "";
+
+  if (ua.includes("npx") || execPath.includes("npx")) {
+    return {
+      installer: "npx",
+      updateCommand: COMMANDS.npx,
+      isEphemeral: true,
+      notes: "Detected npx run — install globally to keep updates persistent.",
+    };
+  }
+
+  if (env.VOLTA_HOME) {
+    return {
+      installer: "volta",
+      updateCommand: COMMANDS.volta,
+      isEphemeral: false,
+    };
+  }
+
+  if (ua.includes("pnpm/")) {
+    return {
+      installer: "pnpm",
+      updateCommand: COMMANDS.pnpm,
+      isEphemeral: false,
+    };
+  }
+  if (ua.includes("yarn/")) {
+    return {
+      installer: "yarn",
+      updateCommand: COMMANDS.yarn,
+      isEphemeral: false,
+    };
+  }
+  if (ua.includes("bun/")) {
+    return {
+      installer: "bun",
+      updateCommand: COMMANDS.bun,
+      isEphemeral: false,
+    };
+  }
+  if (ua.includes("npm/")) {
+    return {
+      installer: "npm",
+      updateCommand: COMMANDS.npm,
+      isEphemeral: false,
+    };
+  }
+
+  return {
+    installer: "npm",
+    updateCommand: COMMANDS.npm,
+    isEphemeral: false,
+  };
+}

--- a/src/cli/version-checker.ts
+++ b/src/cli/version-checker.ts
@@ -1,0 +1,29 @@
+const NPM_REGISTRY = "https://registry.npmjs.org";
+
+export interface FetchOptions {
+  timeoutMs?: number;
+  registry?: string;
+}
+
+export async function fetchLatestVersion(
+  pkgName: string,
+  options: FetchOptions = {},
+): Promise<string | null> {
+  const timeout = options.timeoutMs ?? 10_000;
+  const registry = options.registry ?? NPM_REGISTRY;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    const res = await fetch(`${registry}/${pkgName}/latest`, {
+      signal: controller.signal,
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return typeof data.version === "string" ? data.version : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/cli/version-checker.ts
+++ b/src/cli/version-checker.ts
@@ -10,11 +10,15 @@ export async function fetchLatestVersion(
   options: FetchOptions = {},
 ): Promise<string | null> {
   const timeout = options.timeoutMs ?? 10_000;
-  const registry = options.registry ?? NPM_REGISTRY;
+  const rawRegistry = options.registry ?? NPM_REGISTRY;
+  const registry = rawRegistry.endsWith("/")
+    ? rawRegistry.slice(0, -1)
+    : rawRegistry;
+  const encodedPkg = encodeURIComponent(pkgName);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeout);
   try {
-    const res = await fetch(`${registry}/${pkgName}/latest`, {
+    const res = await fetch(`${registry}/${encodedPkg}/latest`, {
       signal: controller.signal,
       headers: { accept: "application/json" },
     });

--- a/src/cli/version-notifier.ts
+++ b/src/cli/version-notifier.ts
@@ -1,0 +1,38 @@
+import updateNotifier, { type UpdateNotifier, type Package } from "update-notifier";
+
+export interface VersionNotifierResult {
+  notifier: UpdateNotifier | null;
+  skipped: boolean;
+  skipReason?: string;
+}
+
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+
+function shouldSkip(env: NodeJS.ProcessEnv): string | null {
+  const v = env.OMH_SKIP_VERSION_CHECK;
+  if (v === "1" || v === "true") {
+    return "OMH_SKIP_VERSION_CHECK";
+  }
+  return null;
+}
+
+export function notifyIfUpdateAvailable(
+  pkg: Package,
+  env: NodeJS.ProcessEnv = process.env,
+): VersionNotifierResult {
+  const skipReason = shouldSkip(env);
+  if (skipReason) {
+    return { notifier: null, skipped: true, skipReason };
+  }
+
+  try {
+    const notifier = updateNotifier({
+      pkg,
+      updateCheckInterval: ONE_DAY_MS,
+    });
+    notifier.notify({ defer: false, isGlobal: true });
+    return { notifier, skipped: false };
+  } catch {
+    return { notifier: null, skipped: true, skipReason: "error" };
+  }
+}

--- a/tests/integration/cli-update.test.ts
+++ b/tests/integration/cli-update.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { updateCommand } from "../../src/cli/commands/update.js";
+
+describe("updateCommand", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let logs: string[];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    logs = [];
+    logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+      logs.push(args.map(String).join(" "));
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    logSpy.mockRestore();
+  });
+
+  it("reports already up-to-date when versions match", async () => {
+    const result = await updateCommand("0.10.2", {}, {
+      fetchLatest: async () => "0.10.2",
+      spawn: () => ({ status: 0 }),
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.ran).toBe(false);
+    expect(logs.join("\n")).toMatch(/up to date/i);
+  });
+
+  it("reports network failure gracefully when fetcher returns null", async () => {
+    const result = await updateCommand("0.10.2", {}, {
+      fetchLatest: async () => null,
+      spawn: () => ({ status: 0 }),
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.ran).toBe(false);
+  });
+
+  it("dry-run prints command without spawning", async () => {
+    let spawnCalled = false;
+    const result = await updateCommand(
+      "0.10.2",
+      { dryRun: true },
+      {
+        fetchLatest: async () => "0.20.0",
+        spawn: () => {
+          spawnCalled = true;
+          return { status: 0 };
+        },
+      },
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.ran).toBe(false);
+    expect(spawnCalled).toBe(false);
+    expect(result.command).toMatch(/oh-my-harness/);
+  });
+
+  it("--yes flag skips confirm and runs update", async () => {
+    let capturedCmd: string | undefined;
+    let capturedArgs: string[] | undefined;
+    process.env.npm_config_user_agent = "npm/10.0.0 node/v20.0.0";
+    const result = await updateCommand(
+      "0.10.2",
+      { yes: true },
+      {
+        fetchLatest: async () => "0.20.0",
+        spawn: (cmd, args) => {
+          capturedCmd = cmd;
+          capturedArgs = args;
+          return { status: 0 };
+        },
+      },
+    );
+    expect(result.ran).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(capturedCmd).toBe("npm");
+    expect(capturedArgs).toEqual(["install", "-g", "oh-my-harness@latest"]);
+  });
+
+  it("propagates non-zero exit code from spawn failure", async () => {
+    process.env.npm_config_user_agent = "npm/10.0.0 node/v20.0.0";
+    const result = await updateCommand(
+      "0.10.2",
+      { yes: true },
+      {
+        fetchLatest: async () => "0.20.0",
+        spawn: () => ({ status: 1 }),
+      },
+    );
+    expect(result.exitCode).toBe(1);
+    expect(result.ran).toBe(true);
+  });
+
+  it("npx environment skips spawn — prints global install hint", async () => {
+    process.env.npm_config_user_agent =
+      "npm/10.0.0 npx-cli/10.0.0 node/v20.0.0";
+    let spawnCalled = false;
+    const result = await updateCommand(
+      "0.10.2",
+      { yes: true },
+      {
+        fetchLatest: async () => "0.20.0",
+        spawn: () => {
+          spawnCalled = true;
+          return { status: 0 };
+        },
+      },
+    );
+    expect(result.ran).toBe(false);
+    expect(spawnCalled).toBe(false);
+    expect(logs.join("\n")).toMatch(/global/i);
+  });
+});

--- a/tests/unit/installer-detect.test.ts
+++ b/tests/unit/installer-detect.test.ts
@@ -24,12 +24,45 @@ describe("detectInstaller", () => {
     expect(result.updateCommand).toContain("pnpm add -g");
   });
 
-  it("detects yarn from user-agent prefix", () => {
+  it("detects yarn 1.x — uses `yarn global add`", () => {
     const result = detectInstaller(
-      makeEnv({ npm_config_user_agent: "yarn/1.22.0 npm/? node/v20.0.0" }),
+      makeEnv({ npm_config_user_agent: "yarn/1.22.19 npm/? node/v20.0.0" }),
     );
     expect(result.installer).toBe("yarn");
-    expect(result.updateCommand).toContain("yarn global add");
+    expect(result.updateCommand).toBe("yarn global add oh-my-harness@latest");
+  });
+
+  it("detects yarn 2.x — uses `yarn dlx` with note", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "yarn/2.4.3 npm/? node/v20.0.0" }),
+    );
+    expect(result.installer).toBe("yarn");
+    expect(result.updateCommand).toContain("yarn dlx");
+    expect(result.notes).toMatch(/yarn/i);
+  });
+
+  it("detects yarn 3.x — uses `yarn dlx`", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "yarn/3.6.0 npm/? node/v20.0.0" }),
+    );
+    expect(result.installer).toBe("yarn");
+    expect(result.updateCommand).toContain("yarn dlx");
+  });
+
+  it("detects yarn 4.x — uses `yarn dlx`", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "yarn/4.0.2 npm/? node/v20.0.0" }),
+    );
+    expect(result.installer).toBe("yarn");
+    expect(result.updateCommand).toContain("yarn dlx");
+  });
+
+  it("yarn with unparseable version falls back to yarn 1 syntax", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "yarn/abc npm/? node/v20.0.0" }),
+    );
+    expect(result.installer).toBe("yarn");
+    expect(result.updateCommand).toContain("yarn");
   });
 
   it("detects bun from user-agent prefix", () => {
@@ -66,10 +99,18 @@ describe("detectInstaller", () => {
   });
 
   it("update commands all reference oh-my-harness package", () => {
-    const installers = ["npm", "pnpm", "yarn", "bun"];
-    for (const ua of installers) {
+    const cases: Array<[string, string]> = [
+      ["npm", "10.0.0"],
+      ["pnpm", "8.0.0"],
+      ["yarn", "1.22.19"],
+      ["yarn", "4.0.2"],
+      ["bun", "1.0.0"],
+    ];
+    for (const [installer, version] of cases) {
       const result = detectInstaller(
-        makeEnv({ npm_config_user_agent: `${ua}/1.0.0 node/v20.0.0` }),
+        makeEnv({
+          npm_config_user_agent: `${installer}/${version} node/v20.0.0`,
+        }),
       );
       expect(result.updateCommand).toContain("oh-my-harness");
     }

--- a/tests/unit/installer-detect.test.ts
+++ b/tests/unit/installer-detect.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { detectInstaller } from "../../src/cli/installer-detect.js";
+
+function makeEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const base: NodeJS.ProcessEnv = {};
+  return { ...base, ...overrides };
+}
+
+describe("detectInstaller", () => {
+  it("detects npm from user-agent prefix", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "npm/10.0.0 node/v20.0.0 darwin x64" }),
+    );
+    expect(result.installer).toBe("npm");
+    expect(result.updateCommand).toContain("npm install -g");
+    expect(result.isEphemeral).toBe(false);
+  });
+
+  it("detects pnpm from user-agent prefix", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "pnpm/8.0.0 node/v20.0.0 darwin x64" }),
+    );
+    expect(result.installer).toBe("pnpm");
+    expect(result.updateCommand).toContain("pnpm add -g");
+  });
+
+  it("detects yarn from user-agent prefix", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "yarn/1.22.0 npm/? node/v20.0.0" }),
+    );
+    expect(result.installer).toBe("yarn");
+    expect(result.updateCommand).toContain("yarn global add");
+  });
+
+  it("detects bun from user-agent prefix", () => {
+    const result = detectInstaller(
+      makeEnv({ npm_config_user_agent: "bun/1.0.0 node/v20.0.0 darwin x64" }),
+    );
+    expect(result.installer).toBe("bun");
+    expect(result.updateCommand).toContain("bun add -g");
+  });
+
+  it("detects npx — flagged as ephemeral", () => {
+    const result = detectInstaller(
+      makeEnv({
+        npm_config_user_agent: "npm/10.0.0 npx-cli/10.0.0 node/v20.0.0",
+      }),
+    );
+    expect(result.installer).toBe("npx");
+    expect(result.isEphemeral).toBe(true);
+    expect(result.notes).toMatch(/global/i);
+  });
+
+  it("detects volta when VOLTA_HOME is set", () => {
+    const result = detectInstaller(
+      makeEnv({ VOLTA_HOME: "/Users/test/.volta" }),
+    );
+    expect(result.installer).toBe("volta");
+    expect(result.updateCommand).toContain("volta install");
+  });
+
+  it("falls back to npm when no env vars set", () => {
+    const result = detectInstaller(makeEnv());
+    expect(result.installer).toBe("npm");
+    expect(result.updateCommand).toContain("npm install -g");
+  });
+
+  it("update commands all reference oh-my-harness package", () => {
+    const installers = ["npm", "pnpm", "yarn", "bun"];
+    for (const ua of installers) {
+      const result = detectInstaller(
+        makeEnv({ npm_config_user_agent: `${ua}/1.0.0 node/v20.0.0` }),
+      );
+      expect(result.updateCommand).toContain("oh-my-harness");
+    }
+  });
+
+  it("npx detection takes precedence over npm user-agent", () => {
+    const result = detectInstaller(
+      makeEnv({
+        npm_config_user_agent: "npm/10.0.0 npm-cli/10.0.0 node/v20.0.0 ... npx",
+      }),
+    );
+    expect(result.installer).toBe("npx");
+  });
+
+  it("volta detection takes precedence over user-agent", () => {
+    const result = detectInstaller(
+      makeEnv({
+        VOLTA_HOME: "/Users/test/.volta",
+        npm_config_user_agent: "pnpm/8.0.0 node/v20.0.0",
+      }),
+    );
+    expect(result.installer).toBe("volta");
+  });
+});

--- a/tests/unit/version-checker.test.ts
+++ b/tests/unit/version-checker.test.ts
@@ -65,6 +65,32 @@ describe("fetchLatestVersion", () => {
     expect(calledUrl).toBe("https://example.com/bar/latest");
   });
 
+  it("URL-encodes scoped package names", async () => {
+    let calledUrl = "";
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      calledUrl = String(url);
+      return {
+        ok: true,
+        json: async () => ({ version: "1.0.0" }),
+      } as unknown as Response;
+    });
+    await fetchLatestVersion("@scope/pkg");
+    expect(calledUrl).toContain("%40scope%2Fpkg");
+  });
+
+  it("normalizes registry trailing slash", async () => {
+    let calledUrl = "";
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      calledUrl = String(url);
+      return {
+        ok: true,
+        json: async () => ({ version: "1.0.0" }),
+      } as unknown as Response;
+    });
+    await fetchLatestVersion("foo", { registry: "https://example.com/" });
+    expect(calledUrl).toBe("https://example.com/foo/latest");
+  });
+
   it("aborts on timeout", async () => {
     globalThis.fetch = vi.fn(async (_url, opts: RequestInit | undefined) => {
       return new Promise<Response>((_resolve, reject) => {

--- a/tests/unit/version-checker.test.ts
+++ b/tests/unit/version-checker.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchLatestVersion } from "../../src/cli/version-checker.js";
+
+describe("fetchLatestVersion", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns version on 200 response", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({ version: "1.2.3" }),
+        }) as unknown as Response,
+    );
+    expect(await fetchLatestVersion("foo")).toBe("1.2.3");
+  });
+
+  it("returns null on non-ok response", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          json: async () => ({}),
+        }) as unknown as Response,
+    );
+    expect(await fetchLatestVersion("foo")).toBeNull();
+  });
+
+  it("returns null when fetch throws", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network failure");
+    });
+    expect(await fetchLatestVersion("foo")).toBeNull();
+  });
+
+  it("returns null when version field is missing", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({}),
+        }) as unknown as Response,
+    );
+    expect(await fetchLatestVersion("foo")).toBeNull();
+  });
+
+  it("uses custom registry when provided", async () => {
+    let calledUrl = "";
+    globalThis.fetch = vi.fn(async (url: RequestInfo | URL) => {
+      calledUrl = String(url);
+      return {
+        ok: true,
+        json: async () => ({ version: "0.0.1" }),
+      } as unknown as Response;
+    });
+    await fetchLatestVersion("bar", { registry: "https://example.com" });
+    expect(calledUrl).toBe("https://example.com/bar/latest");
+  });
+
+  it("aborts on timeout", async () => {
+    globalThis.fetch = vi.fn(async (_url, opts: RequestInit | undefined) => {
+      return new Promise<Response>((_resolve, reject) => {
+        opts?.signal?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    });
+    expect(await fetchLatestVersion("foo", { timeoutMs: 10 })).toBeNull();
+  });
+});

--- a/tests/unit/version-notifier.test.ts
+++ b/tests/unit/version-notifier.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { notifyIfUpdateAvailable } from "../../src/cli/version-notifier.js";
+
+const PKG = { name: "oh-my-harness", version: "0.10.2" };
+
+describe("notifyIfUpdateAvailable", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("skips when OMH_SKIP_VERSION_CHECK=1", () => {
+    process.env.OMH_SKIP_VERSION_CHECK = "1";
+    const result = notifyIfUpdateAvailable(PKG);
+    expect(result.skipped).toBe(true);
+    expect(result.skipReason).toBe("OMH_SKIP_VERSION_CHECK");
+    expect(result.notifier).toBeNull();
+  });
+
+  it("skips when OMH_SKIP_VERSION_CHECK=true", () => {
+    process.env.OMH_SKIP_VERSION_CHECK = "true";
+    const result = notifyIfUpdateAvailable(PKG);
+    expect(result.skipped).toBe(true);
+  });
+
+  it("does not skip when OMH_SKIP_VERSION_CHECK is empty string", () => {
+    process.env.OMH_SKIP_VERSION_CHECK = "";
+    process.env.NO_UPDATE_NOTIFIER = "1"; // suppress real network behavior
+    const result = notifyIfUpdateAvailable(PKG);
+    expect(result.skipped).toBe(false);
+  });
+
+  it("does not skip when OMH_SKIP_VERSION_CHECK=0", () => {
+    process.env.OMH_SKIP_VERSION_CHECK = "0";
+    process.env.NO_UPDATE_NOTIFIER = "1";
+    const result = notifyIfUpdateAvailable(PKG);
+    expect(result.skipped).toBe(false);
+  });
+
+  it("returns notifier instance when not skipped", () => {
+    delete process.env.OMH_SKIP_VERSION_CHECK;
+    process.env.NO_UPDATE_NOTIFIER = "1";
+    const result = notifyIfUpdateAvailable(PKG);
+    expect(result.notifier).not.toBeNull();
+  });
+
+  it("never throws on errors — best-effort by design", () => {
+    delete process.env.OMH_SKIP_VERSION_CHECK;
+    process.env.NO_UPDATE_NOTIFIER = "1";
+    expect(() => notifyIfUpdateAvailable(PKG)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- 모든 `omh` 실행 시 stderr에 비차단 업데이트 배너 표시 (industry standard via `update-notifier`, 24h 캐시)
- 명시적인 `omh update` 서브커맨드 추가 — installer 자동 감지(npm/pnpm/yarn/bun/volta/npx) 후 y/n 확인 + 실행
- npx 환경은 ephemeral로 표시하고 글로벌 설치 안내만 출력
- skip envs: `OMH_SKIP_VERSION_CHECK=1`, `NO_UPDATE_NOTIFIER`, `CI`, `NODE_ENV=test`, 비-TTY

## Why
사용자가 새 버전 출시를 인지할 수 있는 in-CLI 신호가 없었음. 사실상 표준 패턴(pnpm, NestJS, Angular CLI 등)을 따라 비차단 배너 + 명시적 업데이트 서브커맨드 조합 채택. mid-CLI 자동 `npm i -g`는 EACCES 실패와 실행 중 바이너리 교체 위험으로 회피.

## Test plan
- [x] `npm test` — 1003/1003 passed (신규 22 테스트 포함)
- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run build` clean
- [x] Smoke: `omh --version`, `omh --help`, `omh update --help`
- [x] Smoke: `omh update --dry-run` — 실제 npm registry 호출 후 "Already up to date" 출력
- [ ] 새 버전 출시 후 실제 배너/prompt UX 검수

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시작 시 자동 업데이트 확인 추가
  * `update` CLI 명령 추가로 수동 업데이트 실행 가능
  * npm, pnpm, yarn, bun, volta, npx 등 설치 도구 자동 감지 및 적절한 업데이트 명령 제시
  * `-y/--yes` 및 `--dry-run` 옵션 지원

* **테스트**
  * 업데이트 흐름·설치기 감지·버전 조회에 대한 단위 및 통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->