### PR TITLE
chore: release v0.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.10.2",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Minor release — bumps version to **0.11.0**.

### What's new
- 모든 `omh` 실행 시 비차단 업데이트 배너 (via `update-notifier`, 24h 캐시) — PR #68
- `omh update` 서브커맨드 — installer 자동 감지(npm/pnpm/yarn 1.x/yarn 2+/bun/volta/npx) + y/n 확인 + 실행
- skip envs: `OMH_SKIP_VERSION_CHECK=1`, `NO_UPDATE_NOTIFIER`, `CI`, `NODE_ENV=test`, 비-TTY

### Why minor
새 기능 추가 + 기존 동작 변경 없음 → semver minor.

## Test plan
- [x] `npm test` — 1009/1009 passed
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] PR 머지 시 `auto-release.yml`이 `v0.11.0` 태그 + GitHub Release 자동 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **릴리즈**
  * 패키지 버전이 0.11.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->