### PR TITLE
ci: integrate npm publish into auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,3 +37,51 @@ jobs:
             --title "Release $TAG" \
             --generate-notes \
             --latest
+
+  publish-npm:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - name: Verify CLI works
+        run: node dist/bin/oh-my-harness.js --help
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-github:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Publish to GitHub Packages
+        run: |
+          npm pkg set name="@kyu1204/oh-my-harness"
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
-name: Publish Package
+name: Publish Package (manual fallback)
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish (e.g. v0.11.0)'
+        required: true
+        type: string
   push:
     tags:
       - 'v*'
@@ -13,6 +19,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -35,6 +43,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
v0.11.0 태그/릴리즈는 만들어졌는데 npm에는 publish되지 않은 원인을 수정합니다.

## 원인
- `auto-release.yml`은 `git push origin <tag>`로 태그를 푸시
- 이 푸시는 `GITHUB_TOKEN`이 actor → GitHub Actions가 의도적으로 다른 workflow의 `push`/`tag push` 이벤트를 트리거하지 않음 (무한 루프 방지 정책)
- 따라서 `publish.yml`(`on: push: tags: 'v*'`)이 시동조차 안 됨
- `gh run list`에 v0.11.0 publish workflow가 부재 — 트리거 누락 확인

## 변경
- `auto-release.yml`에 `publish-npm` + `publish-github` job 통합 — `release` job에 needs로 체이닝, 동일 workflow run 내 실행이라 cross-workflow trigger 회피
- `publish.yml`은 `workflow_dispatch` 추가해 manual fallback로 보존 (긴급 재publish 또는 v0.11.0 같은 누락분 복구용)

## v0.11.0 publish 복구 방법
이 PR 머지 후 `publish.yml`을 GitHub Actions UI → Run workflow → tag input에 `v0.11.0` 입력 → 실행. 또는 로컬에서 `npm publish`.

## Test plan
- [x] `js-yaml`로 syntax validation 통과
- [ ] PR 머지 후 다음 release(`release/vX.Y.Z`) 흐름에서 npm publish 자동 실행 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)