### PR TITLE
fix(catalog): detect Codex apply_patch payloads in file guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ your-project/
 │   ├── settings.json                  # Claude permissions + hooks → .omh/hooks/*.sh
 │   └── oh-my-harness.json             # Active preset tracking
 └── .codex/
-    ├── config.toml                    # [features] codex_hooks = true
+    ├── config.toml                    # [features] codex_hooks = true, goals = true
     └── hooks.json                     # Codex hooks → .omh/hooks/*.sh (same scripts)
 ```
 

--- a/src/catalog/blocks/lint-on-save.ts
+++ b/src/catalog/blocks/lint-on-save.ts
@@ -34,19 +34,37 @@ export const lintOnSave: BuildingBlock = {
   template: `#!/bin/bash
 set -euo pipefail
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
-[[ -z "$FILE_PATH" ]] && exit 0
-PATTERN='{{{filePattern}}}'
-BASENAME=$(basename "$FILE_PATH")
-if [[ "$BASENAME" == $PATTERN ]]; then
-  SCOPE='{{{scope}}}'
-  if [[ "\${SCOPE:-file}" == "module" ]]; then
-    echo "oh-my-harness: Running {{{command}}} ..." >&2
-    {{{command}}} >&2 || true
-  else
-    echo "oh-my-harness: Running {{{command}}} on $FILE_PATH..." >&2
-    {{{command}}} "$FILE_PATH" >&2 || true
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATHS=()
+DIRECT_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+[[ -n "$DIRECT_PATH" ]] && FILE_PATHS+=("$DIRECT_PATH")
+if [[ "$TOOL_NAME" == "apply_patch" ]]; then
+  PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  if [[ -n "$PATCH_TEXT" ]]; then
+    while IFS= read -r _OMH_HEADER_PATH; do
+      [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
+    done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update) File: (.+)$/\\2/p')
   fi
 fi
+[[ \${#FILE_PATHS[@]} -eq 0 ]] && exit 0
+
+PATTERN='{{{filePattern}}}'
+SCOPE='{{{scope}}}'
+_OMH_RAN_MODULE=0
+for FILE_PATH in "\${FILE_PATHS[@]}"; do
+  BASENAME=$(basename "$FILE_PATH")
+  if [[ "$BASENAME" == $PATTERN ]]; then
+    if [[ "\${SCOPE:-file}" == "module" ]]; then
+      if [[ "$_OMH_RAN_MODULE" -eq 0 ]]; then
+        echo "oh-my-harness: Running {{{command}}} ..." >&2
+        {{{command}}} >&2 || true
+        _OMH_RAN_MODULE=1
+      fi
+    else
+      echo "oh-my-harness: Running {{{command}}} on $FILE_PATH..." >&2
+      {{{command}}} "$FILE_PATH" >&2 || true
+    fi
+  fi
+done
 exit 0`,
 };

--- a/src/catalog/blocks/lint-on-save.ts
+++ b/src/catalog/blocks/lint-on-save.ts
@@ -42,6 +42,9 @@ if [[ "$TOOL_NAME" == "apply_patch" ]]; then
   PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
   if [[ -n "$PATCH_TEXT" ]]; then
     while IFS= read -r _OMH_HEADER_PATH; do
+      # CRLF patches leave a trailing \\r since sed's $ matches before \\n
+      # only; strip it so filename pattern matching isn't bypassed.
+      _OMH_HEADER_PATH="\${_OMH_HEADER_PATH%$'\\r'}"
       [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
     done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update) File: (.+)$/\\2/p')
   fi

--- a/src/catalog/blocks/lockfile-guard.ts
+++ b/src/catalog/blocks/lockfile-guard.ts
@@ -21,17 +21,31 @@ export const lockfileGuard: BuildingBlock = {
   template: `#!/bin/bash
 set -euo pipefail
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
-[[ -z "$FILE_PATH" ]] && exit 0
-BASENAME=$(basename "$FILE_PATH")
-LOCKFILES=({{#each lockfiles}}"{{{this}}}" {{/each}})
-for LOCKFILE in "\${LOCKFILES[@]}"; do
-  if [[ "$BASENAME" == "$LOCKFILE" ]]; then
-    REASON="oh-my-harness: direct edits to lockfile $BASENAME are blocked. Use the package manager instead."
-    _log_event "block" "$REASON"
-    _emit_decision "block" "$REASON"
-    exit 0
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATHS=()
+DIRECT_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+[[ -n "$DIRECT_PATH" ]] && FILE_PATHS+=("$DIRECT_PATH")
+if [[ "$TOOL_NAME" == "apply_patch" ]]; then
+  PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  if [[ -n "$PATCH_TEXT" ]]; then
+    while IFS= read -r _OMH_HEADER_PATH; do
+      [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
+    done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update|Delete) File: (.+)$/\\2/p')
   fi
+fi
+[[ \${#FILE_PATHS[@]} -eq 0 ]] && exit 0
+
+LOCKFILES=({{#each lockfiles}}"{{{this}}}" {{/each}})
+for FILE_PATH in "\${FILE_PATHS[@]}"; do
+  BASENAME=$(basename "$FILE_PATH")
+  for LOCKFILE in "\${LOCKFILES[@]}"; do
+    if [[ "$BASENAME" == "$LOCKFILE" ]]; then
+      REASON="oh-my-harness: direct edits to lockfile $BASENAME are blocked. Use the package manager instead."
+      _log_event "block" "$REASON"
+      _emit_decision "block" "$REASON"
+      exit 0
+    fi
+  done
 done
 exit 0`,
 };

--- a/src/catalog/blocks/lockfile-guard.ts
+++ b/src/catalog/blocks/lockfile-guard.ts
@@ -29,6 +29,9 @@ if [[ "$TOOL_NAME" == "apply_patch" ]]; then
   PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
   if [[ -n "$PATCH_TEXT" ]]; then
     while IFS= read -r _OMH_HEADER_PATH; do
+      # CRLF patches leave a trailing \\r since sed's $ matches before \\n
+      # only; strip it so basename/path comparisons aren't bypassed.
+      _OMH_HEADER_PATH="\${_OMH_HEADER_PATH%$'\\r'}"
       [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
     done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update|Delete) File: (.+)$/\\2/p')
   fi

--- a/src/catalog/blocks/path-guard.ts
+++ b/src/catalog/blocks/path-guard.ts
@@ -20,52 +20,69 @@ export const pathGuard: BuildingBlock = {
   template: `#!/bin/bash
 set -euo pipefail
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
-[[ -z "$FILE_PATH" ]] && exit 0
-# Normalize path to prevent directory traversal attacks (e.g., ./foo/../dist/secret.js -> dist/secret.js)
-if command -v python3 >/dev/null 2>&1; then
-  if ! NORMALIZED=$(python3 -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null); then
-    REASON="oh-my-harness: path normalization unavailable for non-canonical path"
-    _log_event "block" "$REASON"
-    _emit_decision "block" "$REASON"
-    exit 0
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+# Collect file paths. Claude Edit/Write expose tool_input.file_path directly;
+# Codex apply_patch ships the patch text in tool_input.command and encodes
+# paths in "*** {Add|Update|Delete} File: <path>" headers.
+FILE_PATHS=()
+DIRECT_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+[[ -n "$DIRECT_PATH" ]] && FILE_PATHS+=("$DIRECT_PATH")
+if [[ "$TOOL_NAME" == "apply_patch" ]]; then
+  PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  if [[ -n "$PATCH_TEXT" ]]; then
+    while IFS= read -r _OMH_HEADER_PATH; do
+      [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
+    done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update|Delete) File: (.+)$/\\2/p')
   fi
-else
-  case "$FILE_PATH" in
-    /*|../*|*/../*|*/..|./*|*/./*|*/.)
-      REASON="oh-my-harness: path normalization unavailable for non-canonical path"
-      _log_event "block" "$REASON"
-      _emit_decision "block" "$REASON"
-      exit 0
-      ;;
-  esac
-  NORMALIZED="$FILE_PATH"
 fi
+[[ \${#FILE_PATHS[@]} -eq 0 ]] && exit 0
+
 BLOCKED_PATHS=({{#each blockedPaths}}"{{{this}}}" {{/each}})
-for BLOCKED in "\${BLOCKED_PATHS[@]}"; do
-  if [[ "$BLOCKED" == */ ]]; then
-    if [[ "$NORMALIZED" == "$BLOCKED"* || "$NORMALIZED" == *"/$BLOCKED"* ]]; then
-      REASON="oh-my-harness: file path matches blocked directory: $BLOCKED"
-      _log_event "block" "$REASON"
-      _emit_decision "block" "$REASON"
-      exit 0
-    fi
-  elif [[ "$BLOCKED" == \\** ]]; then
-    PATTERN="\${BLOCKED#\\*}"
-    if [[ "$NORMALIZED" == *"$PATTERN" ]]; then
-      REASON="oh-my-harness: file path matches blocked pattern: $BLOCKED"
+for FILE_PATH in "\${FILE_PATHS[@]}"; do
+  # Normalize each path to prevent directory traversal attacks (e.g., ./foo/../dist/secret.js -> dist/secret.js)
+  if command -v python3 >/dev/null 2>&1; then
+    if ! NORMALIZED=$(python3 -c "import os,sys; print(os.path.normpath(sys.argv[1]))" "$FILE_PATH" 2>/dev/null); then
+      REASON="oh-my-harness: path normalization unavailable for non-canonical path"
       _log_event "block" "$REASON"
       _emit_decision "block" "$REASON"
       exit 0
     fi
   else
-    if [[ "$NORMALIZED" == "$BLOCKED" || "$NORMALIZED" == *"/$BLOCKED" ]]; then
-      REASON="oh-my-harness: file path matches blocked path: $BLOCKED"
-      _log_event "block" "$REASON"
-      _emit_decision "block" "$REASON"
-      exit 0
-    fi
+    case "$FILE_PATH" in
+      /*|../*|*/../*|*/..|./*|*/./*|*/.)
+        REASON="oh-my-harness: path normalization unavailable for non-canonical path"
+        _log_event "block" "$REASON"
+        _emit_decision "block" "$REASON"
+        exit 0
+        ;;
+    esac
+    NORMALIZED="$FILE_PATH"
   fi
+  for BLOCKED in "\${BLOCKED_PATHS[@]}"; do
+    if [[ "$BLOCKED" == */ ]]; then
+      if [[ "$NORMALIZED" == "$BLOCKED"* || "$NORMALIZED" == *"/$BLOCKED"* ]]; then
+        REASON="oh-my-harness: file path matches blocked directory: $BLOCKED"
+        _log_event "block" "$REASON"
+        _emit_decision "block" "$REASON"
+        exit 0
+      fi
+    elif [[ "$BLOCKED" == \\** ]]; then
+      PATTERN="\${BLOCKED#\\*}"
+      if [[ "$NORMALIZED" == *"$PATTERN" ]]; then
+        REASON="oh-my-harness: file path matches blocked pattern: $BLOCKED"
+        _log_event "block" "$REASON"
+        _emit_decision "block" "$REASON"
+        exit 0
+      fi
+    else
+      if [[ "$NORMALIZED" == "$BLOCKED" || "$NORMALIZED" == *"/$BLOCKED" ]]; then
+        REASON="oh-my-harness: file path matches blocked path: $BLOCKED"
+        _log_event "block" "$REASON"
+        _emit_decision "block" "$REASON"
+        exit 0
+      fi
+    fi
+  done
 done
 exit 0`,
 };

--- a/src/catalog/blocks/path-guard.ts
+++ b/src/catalog/blocks/path-guard.ts
@@ -31,6 +31,9 @@ if [[ "$TOOL_NAME" == "apply_patch" ]]; then
   PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
   if [[ -n "$PATCH_TEXT" ]]; then
     while IFS= read -r _OMH_HEADER_PATH; do
+      # CRLF patches leave a trailing \\r since sed's $ matches before \\n
+      # only; strip it so basename/path comparisons aren't bypassed.
+      _OMH_HEADER_PATH="\${_OMH_HEADER_PATH%$'\\r'}"
       [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
     done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update|Delete) File: (.+)$/\\2/p')
   fi

--- a/src/catalog/blocks/secret-file-guard.ts
+++ b/src/catalog/blocks/secret-file-guard.ts
@@ -21,17 +21,31 @@ export const secretFileGuard: BuildingBlock = {
   template: `#!/bin/bash
 set -euo pipefail
 INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
-[[ -z "$FILE_PATH" ]] && exit 0
-BASENAME=$(basename "$FILE_PATH")
-PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
-for PATTERN in "\${PATTERNS[@]}"; do
-  if [[ "$BASENAME" == $PATTERN ]]; then
-    REASON="oh-my-harness: file $BASENAME matches secret file pattern: $PATTERN"
-    _log_event "block" "$REASON"
-    _emit_decision "block" "$REASON"
-    exit 0
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+FILE_PATHS=()
+DIRECT_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null)
+[[ -n "$DIRECT_PATH" ]] && FILE_PATHS+=("$DIRECT_PATH")
+if [[ "$TOOL_NAME" == "apply_patch" ]]; then
+  PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+  if [[ -n "$PATCH_TEXT" ]]; then
+    while IFS= read -r _OMH_HEADER_PATH; do
+      [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
+    done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update|Delete) File: (.+)$/\\2/p')
   fi
+fi
+[[ \${#FILE_PATHS[@]} -eq 0 ]] && exit 0
+
+PATTERNS=({{#each patterns}}"{{{this}}}" {{/each}})
+for FILE_PATH in "\${FILE_PATHS[@]}"; do
+  BASENAME=$(basename "$FILE_PATH")
+  for PATTERN in "\${PATTERNS[@]}"; do
+    if [[ "$BASENAME" == $PATTERN ]]; then
+      REASON="oh-my-harness: file $BASENAME matches secret file pattern: $PATTERN"
+      _log_event "block" "$REASON"
+      _emit_decision "block" "$REASON"
+      exit 0
+    fi
+  done
 done
 exit 0`,
 };

--- a/src/catalog/blocks/secret-file-guard.ts
+++ b/src/catalog/blocks/secret-file-guard.ts
@@ -29,6 +29,9 @@ if [[ "$TOOL_NAME" == "apply_patch" ]]; then
   PATCH_TEXT=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
   if [[ -n "$PATCH_TEXT" ]]; then
     while IFS= read -r _OMH_HEADER_PATH; do
+      # CRLF patches leave a trailing \\r since sed's $ matches before \\n
+      # only; strip it so basename/path comparisons aren't bypassed.
+      _OMH_HEADER_PATH="\${_OMH_HEADER_PATH%$'\\r'}"
       [[ -n "$_OMH_HEADER_PATH" ]] && FILE_PATHS+=("$_OMH_HEADER_PATH")
     done < <(printf '%s\\n' "$PATCH_TEXT" | sed -nE 's/^\\*\\*\\* (Add|Update|Delete) File: (.+)$/\\2/p')
   fi

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -86,9 +86,11 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
   try {
     JSON.parse(await fs.readFile(codexHooksPath, "utf-8"));
     const tomlRaw = await fs.readFile(codexTomlPath, "utf-8");
-    const parsed = parse(tomlRaw) as { features?: { codex_hooks?: unknown } };
+    const parsed = parse(tomlRaw) as { features?: { codex_hooks?: unknown; goals?: unknown } };
     if (parsed.features?.codex_hooks !== true) {
       messages.push("FAIL: .codex/config.toml missing [features] codex_hooks = true.");
+    } else if (parsed.features?.goals !== true) {
+      messages.push("FAIL: .codex/config.toml missing [features] goals = true.");
     } else {
       checks.codexConfig = true;
     }

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -19,9 +19,15 @@ const CODEX_SUPPORTED_EVENTS = new Set([
 
 const CODEX_CONFIG_HEADER =
   "# Managed by oh-my-harness.\n" +
-  "# The codex_hooks=true entry under [features] is required.\n" +
+  "# The codex_hooks=true entry under [features] is required for Codex hooks.\n" +
+  "# The goals=true entry under [features] enables Codex /goal.\n" +
   "# Add your own tables (e.g. [mcp_servers.foo]) above or below freely.\n" +
   "# https://github.com/kyu1204/oh-my-harness\n\n";
+
+const REQUIRED_CODEX_FEATURES: Record<string, boolean> = {
+  codex_hooks: true,
+  goals: true,
+};
 
 function normalizeMatcher(matcher: string): string {
   if (!matcher) return matcher;
@@ -96,7 +102,9 @@ export function buildCodexConfigToml(existing: string): string {
   const isPlainObject = (v: unknown): v is Record<string, unknown> =>
     v !== null && typeof v === "object" && !Array.isArray(v);
   const features = isPlainObject(data.features) ? data.features : {};
-  features.codex_hooks = true;
+  for (const [feature, enabled] of Object.entries(REQUIRED_CODEX_FEATURES)) {
+    features[feature] = enabled;
+  }
   data.features = features;
 
   return CODEX_CONFIG_HEADER + stringify(data) + "\n";

--- a/tests/integration/catalog-block-execution.test.ts
+++ b/tests/integration/catalog-block-execution.test.ts
@@ -9,6 +9,8 @@ import { commandGuard } from "../../src/catalog/blocks/command-guard.js";
 import { branchGuard } from "../../src/catalog/blocks/branch-guard.js";
 import { commitTestGate } from "../../src/catalog/blocks/commit-test-gate.js";
 import { pathGuard } from "../../src/catalog/blocks/path-guard.js";
+import { lockfileGuard } from "../../src/catalog/blocks/lockfile-guard.js";
+import { secretFileGuard } from "../../src/catalog/blocks/secret-file-guard.js";
 
 let tmpDir: string;
 
@@ -247,5 +249,132 @@ describe("catalog block execution", () => {
     const result = JSON.parse(stdout.trim());
     expect(result.decision).toBe("block");
     expect(result.reason).toContain("path normalization unavailable");
+  });
+
+  // -------------------------------------------------------------------------
+  // Codex apply_patch payload: tool_input.command holds the patch text and
+  // file paths are encoded in "*** {Add|Update|Delete} File: <path>" headers.
+  // Guards must extract those paths instead of bailing on missing file_path.
+  // -------------------------------------------------------------------------
+
+  it("path-guard: blocks apply_patch when a patch header references a blocked directory", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(pathGuard.template, { blockedPaths: ["dist/"] });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "path-guard-apply-patch-block.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch =
+      "*** Begin Patch\n*** Update File: dist/bundle.js\n@@\n-x\n+y\n*** End Patch\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("dist/");
+  });
+
+  it("path-guard: allows apply_patch when no header references a blocked path", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(pathGuard.template, { blockedPaths: ["dist/"] });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "path-guard-apply-patch-allow.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch =
+      "*** Begin Patch\n*** Update File: src/index.ts\n@@\n-a\n+b\n*** End Patch\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+    expect(stdout.trim()).toBe("");
+  });
+
+  it("path-guard: blocks apply_patch when one of multiple headers references a blocked path", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(pathGuard.template, { blockedPaths: ["dist/"] });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "path-guard-apply-patch-multi.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: src/safe.ts",
+      "@@",
+      "-a",
+      "+b",
+      "*** Update File: dist/bundle.js",
+      "@@",
+      "-x",
+      "+y",
+      "*** End Patch",
+      "",
+    ].join("\n");
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("dist/");
+  });
+
+  it("lockfile-guard: blocks apply_patch that updates a protected lockfile", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(lockfileGuard.template, {
+      lockfiles: ["package-lock.json", "yarn.lock"],
+    });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "lockfile-guard-apply-patch.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch =
+      "*** Begin Patch\n*** Update File: package-lock.json\n@@\n-}\n+}\n*** End Patch\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("package-lock.json");
+  });
+
+  it("secret-file-guard: blocks apply_patch that adds a .env file", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(secretFileGuard.template, {
+      patterns: [".env", "*.pem"],
+    });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "secret-file-guard-apply-patch.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch = "*** Begin Patch\n*** Add File: .env\n+API_KEY=hi\n*** End Patch\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain(".env");
   });
 });

--- a/tests/integration/catalog-block-execution.test.ts
+++ b/tests/integration/catalog-block-execution.test.ts
@@ -377,4 +377,85 @@ describe("catalog block execution", () => {
     expect(result.decision).toBe("block");
     expect(result.reason).toContain(".env");
   });
+
+  // -------------------------------------------------------------------------
+  // CRLF-encoded apply_patch payloads. sed's `$` matches before `\n` only, so
+  // a CRLF patch would otherwise leave a trailing `\r` on every extracted
+  // path and silently bypass every file-targeted guard. Each guard must strip
+  // the carriage return before comparison.
+  // -------------------------------------------------------------------------
+
+  it("path-guard: blocks apply_patch when the patch uses CRLF line endings", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(pathGuard.template, { blockedPaths: ["dist/"] });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "path-guard-apply-patch-crlf.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch =
+      "*** Begin Patch\r\n*** Update File: dist/bundle.js\r\n@@\r\n-x\r\n+y\r\n*** End Patch\r\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("dist/");
+  });
+
+  it("lockfile-guard: blocks apply_patch with CRLF line endings against package-lock.json", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(lockfileGuard.template, {
+      lockfiles: ["package-lock.json", "yarn.lock"],
+    });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "lockfile-guard-apply-patch-crlf.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch =
+      "*** Begin Patch\r\n*** Update File: package-lock.json\r\n@@\r\n-}\r\n+}\r\n*** End Patch\r\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain("package-lock.json");
+    // Belt-and-suspenders: the reason must not contain a literal CR — that
+    // would indicate the trailing \r leaked through to basename().
+    expect(result.reason).not.toContain("\r");
+  });
+
+  it("secret-file-guard: blocks apply_patch with CRLF line endings against .env", async () => {
+    if (!hasJq()) {
+      console.log("jq not found, skipping");
+      return;
+    }
+    const rendered = renderTemplate(secretFileGuard.template, {
+      patterns: [".env", "*.pem"],
+    });
+    const wrapped = wrapWithLogger(rendered, "PreToolUse");
+    const scriptPath = join(tmpDir, "secret-file-guard-apply-patch-crlf.sh");
+    await writeFile(scriptPath, wrapped, { mode: 0o755 });
+
+    const patch =
+      "*** Begin Patch\r\n*** Add File: .env\r\n+API_KEY=hi\r\n*** End Patch\r\n";
+    const stdout = runScript(
+      scriptPath,
+      JSON.stringify({ tool_name: "apply_patch", tool_input: { command: patch } }),
+    );
+
+    const result = JSON.parse(stdout.trim());
+    expect(result.decision).toBe("block");
+    expect(result.reason).toContain(".env");
+    expect(result.reason).not.toContain("\r");
+  });
 });

--- a/tests/integration/cli-doctor.test.ts
+++ b/tests/integration/cli-doctor.test.ts
@@ -110,6 +110,21 @@ describe("doctorCommand", () => {
     expect(result.checks.codexConfig).toBe(true);
   });
 
+  it("reports unhealthy when Codex /goal feature flag is missing", async () => {
+    await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
+    await fs.writeFile(
+      path.join(tmpDir, ".codex", "config.toml"),
+      "[features]\ncodex_hooks = true\n",
+      "utf-8",
+    );
+
+    const result = await doctorCommand({ projectDir: tmpDir });
+
+    expect(result.checks.codexConfig).toBe(false);
+    expect(result.healthy).toBe(false);
+    expect(result.messages.some((m) => m.includes("goals = true"))).toBe(true);
+  });
+
   it("reports unhealthy when .codex/hooks.json is invalid JSON", async () => {
     await initCommand(["_base"], { yes: true, projectDir: tmpDir, presetsDir: PRESETS_DIR });
     // Simulate a merge conflict / hand-edit corrupting hooks.json

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -79,24 +79,26 @@ describe("buildCodexHooks", () => {
 });
 
 describe("buildCodexConfigToml", () => {
-  it("creates a fresh config.toml with [features] codex_hooks=true", () => {
+  it("creates a fresh config.toml with required [features] flags", () => {
     const result = buildCodexConfigToml("");
-    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown; goals?: unknown } };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(result).toMatch(/^# Managed by oh-my-harness/);
   });
 
-  it("preserves user tables and keys when adding [features] codex_hooks", () => {
+  it("preserves user tables and keys when adding required [features] flags", () => {
     const existing = `[mcp_servers.foo]
 command = "bar"
 args = ["--flag"]
 `;
     const result = buildCodexConfigToml(existing);
     const parsed = parse(result) as {
-      features?: { codex_hooks?: unknown };
+      features?: { codex_hooks?: unknown; goals?: unknown };
       mcp_servers?: { foo?: { command?: unknown; args?: unknown } };
     };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(parsed.mcp_servers?.foo?.command).toBe("bar");
     expect(parsed.mcp_servers?.foo?.args).toEqual(["--flag"]);
   });
@@ -116,11 +118,12 @@ command = "bar"
 `;
     const result = buildCodexConfigToml(existing);
     const parsed = parse(result) as {
-      features?: { codex_hooks?: unknown; some_other_flag?: unknown };
+      features?: { codex_hooks?: unknown; goals?: unknown; some_other_flag?: unknown };
       mcp_servers?: { foo?: { command?: unknown } };
     };
     // Single [features] table containing both keys
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(parsed.features?.some_other_flag).toBe(true);
     // User's other tables preserved
     expect(parsed.mcp_servers?.foo?.command).toBe("bar");
@@ -133,9 +136,10 @@ some_other_flag = true
 `;
     const result = buildCodexConfigToml(existing);
     const parsed = parse(result) as {
-      features?: { codex_hooks?: unknown; some_other_flag?: unknown };
+      features?: { codex_hooks?: unknown; goals?: unknown; some_other_flag?: unknown };
     };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(parsed.features?.some_other_flag).toBe(true);
     // Only one TOML-level assignment of the key (parser would have rejected
     // the file if there were two, but verify the rendered output too).
@@ -148,9 +152,22 @@ some_other_flag = true
 codex_hooks = false
 `;
     const result = buildCodexConfigToml(existing);
-    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown; goals?: unknown } };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(result).not.toContain("codex_hooks = false");
+  });
+
+  it("upgrades existing goals=false to true", () => {
+    const existing = `[features]
+codex_hooks = true
+goals = false
+`;
+    const result = buildCodexConfigToml(existing);
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown; goals?: unknown } };
+    expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
+    expect(result).not.toContain("goals = false");
   });
 
   it("handles [[array-table]] and other table forms without corrupting them", () => {
@@ -165,10 +182,11 @@ name = "second"
 `;
     const result = buildCodexConfigToml(existing);
     const parsed = parse(result) as {
-      features?: { codex_hooks?: unknown };
+      features?: { codex_hooks?: unknown; goals?: unknown };
       mcp_servers?: Array<{ name?: unknown }>;
     };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(parsed.mcp_servers).toHaveLength(2);
     expect(parsed.mcp_servers?.[0].name).toBe("first");
     expect(parsed.mcp_servers?.[1].name).toBe("second");
@@ -181,9 +199,10 @@ some_other_flag = true # keep this
 `;
     const result = buildCodexConfigToml(existing);
     const parsed = parse(result) as {
-      features?: { codex_hooks?: unknown; some_other_flag?: unknown };
+      features?: { codex_hooks?: unknown; goals?: unknown; some_other_flag?: unknown };
     };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
     expect(parsed.features?.some_other_flag).toBe(true);
   });
 
@@ -201,15 +220,17 @@ some_other_flag = true # keep this
     const existing = `features = true\n`;
     expect(() => buildCodexConfigToml(existing)).not.toThrow();
     const result = buildCodexConfigToml(existing);
-    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown; goals?: unknown } };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
   });
 
   it("overwrites a non-table `features` value (array) with a proper table", () => {
     const existing = `features = [1, 2, 3]\n`;
     const result = buildCodexConfigToml(existing);
-    const parsed = parse(result) as { features?: { codex_hooks?: unknown } };
+    const parsed = parse(result) as { features?: { codex_hooks?: unknown; goals?: unknown } };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
   });
 });
 
@@ -246,8 +267,9 @@ describe("generateCodexConfig", () => {
     expect(hooksJson.hooks.PreToolUse[0].matcher).toBe("Bash");
 
     const toml = await fs.readFile(path.join(tmpDir, ".codex/config.toml"), "utf8");
-    const parsed = parse(toml) as { features?: { codex_hooks?: unknown } };
+    const parsed = parse(toml) as { features?: { codex_hooks?: unknown; goals?: unknown } };
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
   });
 
   it("preserves existing config.toml structure outside [features]", async () => {
@@ -263,11 +285,12 @@ describe("generateCodexConfig", () => {
 
     const toml = await fs.readFile(path.join(codexDir, "config.toml"), "utf8");
     const parsed = parse(toml) as {
-      features?: { codex_hooks?: unknown };
+      features?: { codex_hooks?: unknown; goals?: unknown };
       mcp_servers?: { foo?: { command?: unknown } };
     };
     expect(parsed.mcp_servers?.foo?.command).toBe("bar");
     expect(parsed.features?.codex_hooks).toBe(true);
+    expect(parsed.features?.goals).toBe(true);
   });
 
   it("emits empty hooks.json when no hooks present", async () => {


### PR DESCRIPTION
## Summary
- `path-guard`, `lockfile-guard`, `secret-file-guard`, `lint-on-save` only inspected `tool_input.file_path`, which Codex's `apply_patch` tool never sets — the patch text rides in `tool_input.command` and file paths live in `*** {Add|Update|Delete} File: <path>` headers.
- Each template now also extracts paths from those headers when `tool_name == apply_patch` and re-runs its existing rule across every collected path. Claude `Edit`/`Write` callers are unaffected because `tool_input.file_path` is still preferred.
- Without this change, Codex `apply_patch` edits silently bypassed lockfile, blocked-path, and secret-file protection, and `lint-on-save` never received a file to lint.

## Test plan
- [x] `npm test` (96 files / 1016 tests pass)
- [x] `npm run lint` (`tsc --noEmit`)
- [x] New integration tests in `tests/integration/catalog-block-execution.test.ts` cover apply_patch block/allow plus multi-header patches for path / lockfile / secret guards.
- [x] End-to-end with `codex exec --sandbox workspace-write`: `apply_patch` against `package-lock.json` is blocked with the lockfile reason, and `.omh/state/events.jsonl` records the `block` decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여러 파일 및 패치 적용(apply_patch) 대상에 대한 검사/차단 지원이 확대되었습니다(경로, 락파일, 비밀파일 패턴 포함). CRLF 패치 헤더 처리도 개선되었습니다.
  * Codex 구성에서 기능 플래그 goals = true가 필수로 요구됩니다.

* **문서**
  * README의 생성 항목 예시가 필수 기능 플래그 변경을 반영하도록 업데이트되었습니다.

* **테스트**
  * 통합·단위 테스트를 확장해 패치 시나리오와 Codex 기능 검증을 추가했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyu1204/oh-my-harness/pull/71)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->