### PR TITLE
fix(tests): strip ANSI in stats-timeline assertions so TTY runs match CI

### DIFF
--- a/tests/unit/stats-timeline.test.tsx
+++ b/tests/unit/stats-timeline.test.tsx
@@ -5,6 +5,17 @@ import { render } from "ink-testing-library";
 import { Timeline } from "../../src/cli/stats/components/Timeline.js";
 import type { StatsData, HourlyBucket } from "../../src/cli/stats/data.js";
 
+// ink emits ANSI color escapes when stdout is a TTY (local dev terminals) but
+// not in non-TTY environments like CI. Substring assertions against the raw
+// frame are therefore environment-dependent — e.g. `Block rate: 25%` becomes
+// `Block rate: \x1b[31m25%\x1b[39m` once the renderer wraps the number in a
+// colored <Text>. Strip ANSI before asserting so the same expectations hold
+// whether or not chalk decides to colorize.
+function stripAnsi(input: string): string {
+  // eslint-disable-next-line no-control-regex
+  return input.replace(/\x1b\[\d+m/g, "");
+}
+
 function makeHourlyBuckets(overrides: Partial<Record<number, { total: number; blockCount: number; allowCount: number }>> = {}): HourlyBucket[] {
   return Array.from({ length: 24 }, (_, hour) => ({
     hour,
@@ -35,35 +46,35 @@ describe("Timeline", () => {
   it("renders Events summary with total count", () => {
     const data = makeStatsData({ totalEvents: 42 });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("Events: 42");
   });
 
   it("renders block rate percentage", () => {
     const data = makeStatsData({ blockRate: 25 });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("Block rate: 25%");
   });
 
   it("renders peak hour in HH:00 format", () => {
     const data = makeStatsData({ peakHour: 9 });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("Peak: 09:00");
   });
 
   it("renders date range label", () => {
     const data = makeStatsData({ dateRange: "today" });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("Range: today");
   });
 
   it("shows No events recorded when all buckets are zero", () => {
     const data = makeStatsData({ totalEvents: 0 });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("No events recorded");
   });
 
@@ -76,7 +87,7 @@ describe("Timeline", () => {
       }),
     });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("14:00");
     expect(frame).toContain("10 events");
   });
@@ -90,7 +101,7 @@ describe("Timeline", () => {
       }),
     });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     expect(frame).toContain("3 block");
   });
 
@@ -102,7 +113,7 @@ describe("Timeline", () => {
       }),
     });
     const { lastFrame } = render(React.createElement(Timeline, { data }));
-    const frame = lastFrame() ?? "";
+    const frame = stripAnsi(lastFrame() ?? "");
     // heatmap chars: ░ ▒ ▓ █
     const heatmapChars = (frame.match(/[░▒▓█]/g) ?? []);
     expect(heatmapChars.length).toBeGreaterThanOrEqual(24);

--- a/tests/unit/stats-timeline.test.tsx
+++ b/tests/unit/stats-timeline.test.tsx
@@ -9,11 +9,12 @@ import type { StatsData, HourlyBucket } from "../../src/cli/stats/data.js";
 // not in non-TTY environments like CI. Substring assertions against the raw
 // frame are therefore environment-dependent — e.g. `Block rate: 25%` becomes
 // `Block rate: \x1b[31m25%\x1b[39m` once the renderer wraps the number in a
-// colored <Text>. Strip ANSI before asserting so the same expectations hold
-// whether or not chalk decides to colorize.
+// colored <Text>. Strip every SGR sequence — single-parameter `\x1b[31m`,
+// compound `\x1b[1;31m`, and 256-color `\x1b[38;5;196m` alike — so the same
+// expectations hold whether or not chalk decides to colorize.
 function stripAnsi(input: string): string {
   // eslint-disable-next-line no-control-regex
-  return input.replace(/\x1b\[\d+m/g, "");
+  return input.replace(/\x1B\[[0-9;]*m/g, "");
 }
 
 function makeHourlyBuckets(overrides: Partial<Record<number, { total: number; blockCount: number; allowCount: number }>> = {}): HourlyBucket[] {


### PR DESCRIPTION
## Summary
- `tests/unit/stats-timeline.test.tsx`의 substring 매칭이 로컬(TTY)에서는 깨지고 CI(비-TTY)에서는 통과하는 환경 의존 회귀를 수정.
- `Timeline.tsx`가 퍼센트를 색상이 적용된 자식 `<Text>`로 감싸 ink가 `Block rate: \x1b[31m25%\x1b[39m`를 emit → `toContain("Block rate: 25%")`가 substring으로 매칭되지 못함.
- 테스트에 `stripAnsi(input)` 헬퍼를 추가하고, 컴포넌트 출력에 컬러가 들어갈 수 있는 모든 `lastFrame()` 호출에 적용. 컴포넌트의 시각적 UX(빨강/초록 컬러)는 그대로 유지.

## Why this CI didn't catch it
- `chalk`/`supports-color`가 비-TTY + `CI=true` 환경에서 ANSI 코드를 자동 끔.
- 로컬 macOS Terminal은 TTY라 ANSI 코드가 들어가 substring 분할로 실패.

## Test plan
- [x] `FORCE_COLOR=1 npx vitest run tests/unit/stats-timeline.test.tsx` → 패치 전 RED, 패치 후 GREEN
- [x] `CI=true FORCE_COLOR=0 npx vitest run tests/unit/stats-timeline.test.tsx` → 변함없이 GREEN
- [x] `FORCE_COLOR=1 npm test` 전체 1019/1019 GREEN
- [x] `npm run lint` (`tsc --noEmit`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **테스트**
  * Timeline 테스트의 환경 간 일관성 개선으로 다양한 실행 환경에서 안정적인 결과 보장

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyu1204/oh-my-harness/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->