### PR TITLE
fix(init): emit harness.yaml from preset flow and relax schema

### DIFF
--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -6,6 +6,7 @@ import * as clack from "@clack/prompts";
 import { createDefaultRegistry } from "../../catalog/registry.js";
 import type { HookEntry, ParamDefinition } from "../../catalog/types.js";
 import { syncCommand } from "./sync.js";
+import { buildMinimalHarnessConfig } from "../../core/harness-defaults.js";
 
 export interface HookAddOptions {
   yes?: boolean;
@@ -29,7 +30,12 @@ async function readHarnessYaml(projectDir: string): Promise<HarnessYamlWithHooks
   } catch (err) {
     const error = err as NodeJS.ErrnoException;
     if (error.code === "ENOENT") {
-      return {};
+      // Bootstrap a schema-conformant skeleton on first use so that
+      // `omh hook add` works before the user has run `omh init`.
+      // stacks are populated from the deterministic project detector so the
+      // generated yaml is informative rather than empty.
+      const minimal = await buildMinimalHarnessConfig(projectDir);
+      return minimal as unknown as HarnessYamlWithHooks;
     }
     throw error;
   }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -12,6 +12,7 @@ import type { ProjectFacts } from "../../detector/project-detector.js";
 import { harnessToMergedConfig } from "../../core/harness-converter.js";
 import { harnessToMergedConfigV2 } from "../../core/harness-converter-v2.js";
 import { createDefaultRegistry } from "../../catalog/registry.js";
+import { buildMinimalHarnessConfig, ensureHarnessYaml } from "../../core/harness-defaults.js";
 
 export interface InitOptions {
   yes?: boolean;
@@ -240,6 +241,12 @@ async function initWithPresets(
   const config = mergePresets(presetConfigs);
   const result = await generate({ projectDir, config });
 
+  // Emit a schema-conformant harness.yaml so subsequent `omh hook add`,
+  // `omh sync`, and `omh test` invocations operate on a single source of
+  // truth instead of failing on missing yaml.
+  const minimal = await buildMinimalHarnessConfig(projectDir, { presetNames });
+  const yamlInfo = await ensureHarnessYaml(projectDir, minimal);
+
   await writeHarnessState(projectDir, {
     presets: names,
     generatedAt: new Date().toISOString(),
@@ -250,6 +257,9 @@ async function initWithPresets(
   console.log("Generated files:");
   for (const f of result.files) {
     console.log(`  ${f}`);
+  }
+  if (yamlInfo.created) {
+    console.log(`  ${yamlInfo.path}`);
   }
 }
 
@@ -285,6 +295,10 @@ async function initWithPresetsLegacy(
   const config = mergePresets(presetConfigs);
   const result = await generate({ projectDir, config });
 
+  // Emit minimal harness.yaml (see initWithPresets for rationale).
+  const minimal = await buildMinimalHarnessConfig(projectDir, { presetNames });
+  const yamlInfo = await ensureHarnessYaml(projectDir, minimal);
+
   await writeHarnessState(projectDir, {
     presets: names,
     generatedAt: new Date().toISOString(),
@@ -295,5 +309,8 @@ async function initWithPresetsLegacy(
   console.log("Generated files:");
   for (const f of result.files) {
     console.log(`  ${f}`);
+  }
+  if (yamlInfo.created) {
+    console.log(`  ${yamlInfo.path}`);
   }
 }

--- a/src/core/harness-defaults.ts
+++ b/src/core/harness-defaults.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "js-yaml";
+import type { HarnessConfig } from "./harness-schema.js";
+import { detectProject } from "../detector/project-detector.js";
+
+export interface BuildMinimalConfigOptions {
+  presetNames?: string[];
+  description?: string;
+}
+
+/**
+ * Synthesize a schema-conformant minimal HarnessConfig that downstream
+ * commands (sync, test, hook add) can operate on.
+ *
+ * - project.stacks is populated from the deterministic project detector
+ *   when possible, falling back to a single stack derived from the first
+ *   preset name (so `omh init --preset nextjs` in an empty directory still
+ *   yields a stacks-aware yaml).
+ * - hooks / enforcement / rules / permissions start empty — they are the
+ *   surfaces users grow as they invoke `omh hook add` or hand-edit.
+ */
+export async function buildMinimalHarnessConfig(
+  projectDir: string,
+  options: BuildMinimalConfigOptions = {},
+): Promise<HarnessConfig> {
+  let facts: Awaited<ReturnType<typeof detectProject>> | undefined;
+  try {
+    facts = await detectProject(projectDir);
+  } catch {
+    facts = undefined;
+  }
+
+  const presetHint = options.presetNames?.find((n) => n && n !== "_base");
+  const stackName = presetHint ?? facts?.frameworks[0] ?? "app";
+  const framework = facts?.frameworks[0] ?? presetHint ?? "unknown";
+  const language = facts?.languages[0] ?? "unknown";
+  const packageManager = facts?.packageManagers[0];
+
+  const hasAnyFact =
+    !!facts &&
+    (facts.languages.length > 0 ||
+      facts.frameworks.length > 0 ||
+      facts.packageManagers.length > 0);
+
+  const stacks =
+    hasAnyFact || presetHint
+      ? [
+          {
+            name: stackName,
+            framework,
+            language,
+            ...(packageManager ? { packageManager } : {}),
+          },
+        ]
+      : [];
+
+  return {
+    version: "1.0",
+    project: {
+      ...(options.description ? { description: options.description } : {}),
+      stacks,
+    },
+    rules: [],
+    enforcement: {
+      preCommit: [],
+      blockedPaths: [],
+      blockedCommands: [],
+      postSave: [],
+    },
+    hooks: [],
+    permissions: { allow: [], deny: [] },
+  };
+}
+
+/**
+ * Write `harness.yaml` to projectDir, but only if one does not already
+ * exist — never clobber a hand-edited config.
+ *
+ * Returns the absolute path when a file is written (or already existed),
+ * and a flag indicating whether a fresh file was created.
+ */
+export async function ensureHarnessYaml(
+  projectDir: string,
+  config: HarnessConfig,
+): Promise<{ path: string; created: boolean }> {
+  const harnessPath = path.join(projectDir, "harness.yaml");
+  try {
+    await fs.access(harnessPath);
+    return { path: harnessPath, created: false };
+  } catch {
+    // ENOENT — write fresh
+  }
+  await fs.writeFile(harnessPath, yaml.dump(config, { lineWidth: 120 }), "utf-8");
+  return { path: harnessPath, created: true };
+}

--- a/src/core/harness-schema.ts
+++ b/src/core/harness-schema.ts
@@ -4,7 +4,8 @@ import { HookEntrySchema } from "../catalog/types.js";
 export const HarnessConfigSchema = z.object({
   version: z.literal("1.0").default("1.0"),
 
-  // Project info (from NL parsing)
+  // Project info (from NL parsing or preset detector). Optional so a minimal
+  // hooks-only harness.yaml (the shape shown in README) still validates.
   project: z.object({
     name: z.string().optional(),
     description: z.string().optional(),
@@ -15,8 +16,8 @@ export const HarnessConfigSchema = z.object({
       packageManager: z.string().optional(),
       testRunner: z.string().optional(),
       linter: z.string().optional(),
-    })),
-  }),
+    })).default([]),
+  }).default({ stacks: [] }),
 
   // Rules injected into CLAUDE.md
   rules: z.array(z.object({
@@ -24,7 +25,7 @@ export const HarnessConfigSchema = z.object({
     title: z.string(),
     content: z.string(),
     priority: z.number().default(50),
-  })),
+  })).default([]),
 
   // Enforcement hooks
   enforcement: z.object({

--- a/tests/unit/cli-hook-add-bootstrap.test.ts
+++ b/tests/unit/cli-hook-add-bootstrap.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import yaml from "js-yaml";
+import { HarnessConfigSchema } from "../../src/core/harness-schema.js";
+
+describe("hookAddCommand bootstraps harness.yaml when missing", () => {
+  let tmpDir: string;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-hook-add-"));
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("creates a schema-conformant harness.yaml when one does not exist", async () => {
+    const { hookAddCommand } = await import("../../src/cli/commands/hook.js");
+
+    await hookAddCommand("tdd-guard", { projectDir: tmpDir, yes: true });
+
+    const harnessPath = path.join(tmpDir, "harness.yaml");
+    const raw = await fs.readFile(harnessPath, "utf-8");
+    const parsed = yaml.load(raw);
+    const result = HarnessConfigSchema.safeParse(parsed);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const tdd = result.data.hooks.find((h) => h.block === "tdd-guard");
+      expect(tdd).toBeDefined();
+    }
+  });
+
+  it("does not emit schema-validation errors after bootstrap", async () => {
+    const { hookAddCommand } = await import("../../src/cli/commands/hook.js");
+    await hookAddCommand("tdd-guard", { projectDir: tmpDir, yes: true });
+
+    const errors = consoleErrorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(errors).not.toContain("validation failed");
+    expect(errors).not.toContain("project: Required");
+    expect(errors).not.toContain("rules: Required");
+  });
+
+  it("writes the catalog-<id>.sh hook script under .omh/hooks", async () => {
+    const { hookAddCommand } = await import("../../src/cli/commands/hook.js");
+    await hookAddCommand("branch-guard", { projectDir: tmpDir, yes: true });
+
+    const hookPath = path.join(tmpDir, ".omh", "hooks", "catalog-branch-guard.sh");
+    const exists = await fs.stat(hookPath).then(() => true).catch(() => false);
+    expect(exists).toBe(true);
+  });
+});

--- a/tests/unit/cli-init-preset-yaml.test.ts
+++ b/tests/unit/cli-init-preset-yaml.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import yaml from "js-yaml";
+import { HarnessConfigSchema } from "../../src/core/harness-schema.js";
+
+describe("initCommand --preset emits harness.yaml", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-init-preset-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes harness.yaml after preset-based init", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "demo", scripts: { test: "vitest" } }),
+      "utf-8",
+    );
+
+    const { initCommand } = await import("../../src/cli/commands/init.js");
+    await initCommand([], {
+      projectDir: tmpDir,
+      preset: ["nextjs"],
+      yes: true,
+    });
+
+    const harnessPath = path.join(tmpDir, "harness.yaml");
+    const exists = await fs
+      .stat(harnessPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(true);
+
+    const raw = await fs.readFile(harnessPath, "utf-8");
+    const parsed = yaml.load(raw);
+    const result = HarnessConfigSchema.safeParse(parsed);
+    expect(result.success).toBe(true);
+  });
+
+  it("emitted harness.yaml is sync-compatible (no schema errors)", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify({ name: "demo" }),
+      "utf-8",
+    );
+
+    const { initCommand } = await import("../../src/cli/commands/init.js");
+    await initCommand([], { projectDir: tmpDir, preset: ["nextjs"], yes: true });
+
+    const { syncCommand } = await import("../../src/cli/commands/sync.js");
+    let exited = false;
+    const origExit = process.exit;
+    process.exit = ((code?: number) => {
+      if (code && code !== 0) exited = true;
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit;
+    try {
+      await syncCommand({ projectDir: tmpDir }).catch(() => {});
+    } finally {
+      process.exit = origExit;
+    }
+    expect(exited).toBe(false);
+  });
+});

--- a/tests/unit/detector/init-integration.test.ts
+++ b/tests/unit/detector/init-integration.test.ts
@@ -147,7 +147,11 @@ describe("NL init flow + detectProject integration", () => {
     }
   });
 
-  it("does not call detectProject for preset-based init", async () => {
+  it("calls detectProject for preset-based init to populate harness.yaml stacks", async () => {
+    // Preset-based init now also emits a schema-conformant harness.yaml so
+    // downstream `omh hook add`/`omh sync`/`omh test` operate on a single
+    // source of truth. The detector is used solely to populate stacks in
+    // that emitted yaml — it is not passed to any NL runner.
     const { initCommand } = await import("../../../src/cli/commands/init.js");
 
     await initCommand(["_base"], {
@@ -156,6 +160,8 @@ describe("NL init flow + detectProject integration", () => {
       presetsDir: PRESETS_DIR,
     });
 
-    expect(mockDetectProject).not.toHaveBeenCalled();
+    expect(mockDetectProject).toHaveBeenCalledWith(tmpDir);
+    // NL generator must not be involved in preset flow.
+    expect(mockGenerateHarnessConfig).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/harness-schema-minimal.test.ts
+++ b/tests/unit/harness-schema-minimal.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { HarnessConfigSchema } from "../../src/core/harness-schema.js";
+
+describe("HarnessConfigSchema minimal forms", () => {
+  it("accepts an entirely empty yaml object and applies defaults", () => {
+    const result = HarnessConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe("1.0");
+      expect(result.data.project.stacks).toEqual([]);
+      expect(result.data.rules).toEqual([]);
+      expect(result.data.hooks).toEqual([]);
+      expect(result.data.enforcement.preCommit).toEqual([]);
+      expect(result.data.permissions).toEqual({ allow: [], deny: [] });
+    }
+  });
+
+  it("accepts the README hooks-only example shape", () => {
+    const readmeExample = {
+      hooks: [
+        { block: "branch-guard" },
+        { block: "tdd-guard" },
+        { block: "commit-test-gate", params: { testCommand: "npx vitest run" } },
+        { block: "path-guard", params: { blockedPaths: ["node_modules/", "dist/"] } },
+        { block: "command-guard", params: { patterns: ["rm -rf /", "sudo rm"] } },
+        { block: "lint-on-save", params: { filePattern: "*.ts", command: "npx eslint --fix" } },
+        { block: "auto-pr", params: { baseBranch: "main" } },
+      ],
+    };
+    const result = HarnessConfigSchema.safeParse(readmeExample);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.hooks).toHaveLength(7);
+      expect(result.data.project.stacks).toEqual([]);
+      expect(result.data.rules).toEqual([]);
+    }
+  });
+
+  it("accepts project without stacks", () => {
+    const result = HarnessConfigSchema.safeParse({ project: { name: "x" } });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.project.name).toBe("x");
+      expect(result.data.project.stacks).toEqual([]);
+    }
+  });
+});

--- a/tests/unit/nl-parse-intent.test.ts
+++ b/tests/unit/nl-parse-intent.test.ts
@@ -304,8 +304,16 @@ describe("generateHarnessConfig", () => {
     await expect(generateHarnessConfig("some app", mockRunner)).rejects.toThrow();
   });
 
-  it("throws when YAML is missing required schema fields", async () => {
-    const mockRunner: ClaudeRunner = async () => yaml.dump({ version: "1.0", project: {} });
+  it("throws when YAML has invalid stack shape (missing required name)", async () => {
+    // The top-level project/rules fields became defaulted in v1.1 to support
+    // the README hooks-only shape, so the negative case now lives inside the
+    // nested stack object where `name` is still required.
+    const mockRunner: ClaudeRunner = async () =>
+      yaml.dump({
+        version: "1.0",
+        project: { stacks: [{ framework: "nextjs", language: "typescript" }] },
+        rules: [],
+      });
     await expect(generateHarnessConfig("some app", mockRunner)).rejects.toThrow();
   });
 


### PR DESCRIPTION
## Summary

E2E QA에서 발견한 3건의 Critical 결함을 단일 root cause 기반으로 해소.

- `omh init --preset` 후 `omh test` → `0/0 checks passed` (README는 14/14 데모)
- `omh hook add -y` → `harness.yaml validation failed: project: Required, rules: Required` 로 silent failure (yaml에는 추가됐는데 `.omh/hooks/`/settings 미반영)
- README `harness.yaml` 예시 (line 195-219)가 Zod schema(`project.stacks`/`rules` required)에 의해 reject

세 결함 모두 **`initWithPresets`가 yaml을 emit하지 않으면서 `syncCommand`/`hookAddCommand`/`testCommand`는 schema-conformant yaml을 전제로 동작**하는 mismatch에서 발생.

## Changes

- `src/core/harness-schema.ts`: `project`(default `{stacks:[]}`), `project.stacks`(default `[]`), `rules`(default `[]`)로 완화. README 예시 그대로 통과 + 기존 yaml과 100% 호환.
- `src/core/harness-defaults.ts` (신규): `buildMinimalHarnessConfig` + `ensureHarnessYaml` 헬퍼. `detectProject` 결과로 stacks 자동 채움.
- `src/cli/commands/init.ts`: `initWithPresets` / `initWithPresetsLegacy` 양쪽에서 yaml을 emit. 기존 yaml은 덮어쓰지 않음 (사용자 데이터 보존).
- `src/cli/commands/hook.ts`: yaml 부재 시 minimal skeleton으로 부트스트랩 — `omh hook add`가 `omh init` 전에도 동작.

## Test plan

- [x] `tests/unit/harness-schema-minimal.test.ts` (3): 빈 yaml + README 예시 + project만-stacks-없음 모두 통과
- [x] `tests/unit/cli-init-preset-yaml.test.ts` (2): preset init이 schema-conformant harness.yaml emit + 동일 yaml로 `syncCommand` 무에러
- [x] `tests/unit/cli-hook-add-bootstrap.test.ts` (3): yaml 없는 fixture에서 `hookAddCommand("tdd-guard", {yes:true})` → schema 통과 + `validation failed` 메시지 없음 + `.omh/hooks/catalog-tdd-guard.sh` 실제 생성
- [x] 의도 변경된 두 회귀 갱신: `tests/unit/nl-parse-intent.test.ts`("invalid stack shape" 음성 케이스로 대체), `tests/unit/detector/init-integration.test.ts` (preset flow도 detector 사용한다는 새 계약 반영)
- [x] `npm run lint` (tsc --noEmit) — pass
- [x] `npx vitest run` — **1027/1027 pass** (0 fail)
- [x] E2E: nextjs fixture에서 `init --preset → hook add tdd-guard -y → omh test` → 3/3 checks passed (이전 0/0), `omh doctor` all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `omh hook add` 명령을 초기화 전에 사용할 수 있게 개선
  * 필요시 자동으로 최소 구성의 `harness.yaml` 생성

* **개선 사항**
  * 스키마 기본값 확장으로 더욱 견고한 구성 처리
  * 프리셋 기반 초기화 시 생성된 파일 경로 로그 추가

* **테스트**
  * 부트스트랩 및 스키마 호환성 검증 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyu1204/oh-my-harness/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->