### PR TITLE
docs(readme): replace Cursor/GitHub Copilot emitter with PI emitter in roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,8 +405,7 @@ oh-my-harness/
 - [x] GitHub star prompt — first-time only
 - [x] Codex emitter — `AGENTS.md` + `.codex/hooks.json` + `.codex/config.toml`
 - [x] Unified `.omh/` layout — single source of truth for hooks & state across runtimes
-- [ ] Cursor (`.cursor/rules/`) emitter
-- [ ] GitHub Copilot emitter
+- [ ] PI emitter
 - [ ] Community preset registry
 - [ ] `omh modify "change X"` — NL config editing
 


### PR DESCRIPTION
## Summary

- 로드맵에서 `Cursor (.cursor/rules/) emitter`와 `GitHub Copilot emitter` 항목 제거
- `PI emitter` 항목으로 통합 교체

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서**
  * 로드맵에 PI emitter 항목이 추가되었습니다.
  * Cursor (.cursor/rules/) emitter 및 GitHub Copilot emitter 항목이 제거되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyu1204/oh-my-harness/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->