### PR TITLE
docs(readme): fix PI emitter roadmap entry to reference pi.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ oh-my-harness/
 - [x] Codex emitter — `AGENTS.md` + `.codex/hooks.json` + `.codex/config.toml`
 - [x] Unified `.omh/` layout — single source of truth for hooks & state across runtimes
 - [ ] Cursor (`.cursor/rules/`) emitter
-- [ ] PI (Process Isolation) emitter — sandboxed tool execution
+- [ ] Pi ([pi.dev](https://pi.dev)) emitter — generate harness config for the Pi coding agent
 - [ ] `ask` mode — request approval before executing risky tools
 - [ ] Community harness.yaml registry — share and reuse configs
 - [ ] `omh modify "change X"` — NL config editing


### PR DESCRIPTION
## What

The roadmap entry for the PI emitter incorrectly described it as **"Process Isolation — sandboxed tool execution"**.

PI actually refers to **[pi.dev](https://pi.dev)** — the Pi coding agent harness (an agent runtime like Claude Code / Codex), introduced into the roadmap in d04d4f8. The 'Process Isolation / sandboxed' wording was an inaccurate description carried over by mistake.

## Change

```diff
- - [ ] PI (Process Isolation) emitter — sandboxed tool execution
+ - [ ] Pi ([pi.dev](https://pi.dev)) emitter — generate harness config for the Pi coding agent
```

Docs-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)