### PR TITLE
feat(hooks): add ask mode for blocking hooks (runtime-detecting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ oh-my-harness/
 - [x] Unified `.omh/` layout — single source of truth for hooks & state across runtimes
 - [ ] Cursor (`.cursor/rules/`) emitter
 - [ ] Pi ([pi.dev](https://pi.dev)) emitter — generate harness config for the Pi coding agent
-- [ ] `ask` mode — request approval before executing risky tools
+- [x] `ask` mode — request approval before executing risky tools (Claude; Codex falls back to block)
 - [ ] Community harness.yaml registry — share and reuse configs
 - [ ] `omh modify "change X"` — NL config editing
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ All enforcement is powered by **catalog blocks** — reusable, parameterized hoo
 hooks:
   - block: branch-guard
   - block: tdd-guard
+    mode: ask          # ask for approval instead of hard-blocking (Claude)
   - block: commit-test-gate
     params:
       testCommand: "npx vitest run"
@@ -216,6 +217,20 @@ hooks:
     params:
       baseBranch: main
 ```
+
+#### `mode`: block vs. ask
+
+Any blocking hook accepts an optional `mode` (default `block`):
+
+- **`block`** — hard-blocks the tool call. The agent cannot proceed.
+- **`ask`** — escalates to the user for approval instead of blocking outright.
+  - **Claude Code**: shows a native permission prompt (`permissionDecision: "ask"`).
+  - **Codex**: `ask` is **not** supported, so the hook falls back to a hard
+    block — your guardrail is never silently downgraded to "allow". The same
+    generated script detects the calling runtime and responds accordingly.
+
+`mode: ask` only applies to blocks that can block (`canBlock: true`); setting it
+on a non-blocking block (e.g. `lint-on-save`) is reported and ignored.
 
 ---
 

--- a/src/catalog/converter.ts
+++ b/src/catalog/converter.ts
@@ -7,6 +7,7 @@ export interface HookConfigEntry {
   type: "command";
   command: string;
   matcher?: string;
+  mode?: "block" | "ask";
 }
 
 export interface ConvertResult {
@@ -55,9 +56,21 @@ export async function convertHookEntries(
     const scriptPath = `${OMH_HOOKS_DIR}/${scriptName}`;
     scripts.set(scriptPath, scriptContent);
 
+    // Resolve ask/block mode. "ask" only makes sense for blocks that can
+    // block a tool call; for non-blocking blocks it is meaningless, so warn
+    // and fall back to "block" rather than emitting a no-op ask.
+    let mode: "block" | "ask" = entry.mode ?? "block";
+    if (mode === "ask" && !block.canBlock) {
+      errors.push(
+        `Block "${entry.block}" does not support ask mode (canBlock=false); falling back to block.`,
+      );
+      mode = "block";
+    }
+
     const hookEntry: HookConfigEntry = {
       type: "command",
       command: scriptPath,
+      mode,
     };
 
     if (block.matcher) {

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -61,6 +61,10 @@ export interface BuildingBlock {
 export interface HookEntry {
   block: string;
   params: Record<string, unknown>;
+  // "block" (default) hard-blocks the tool call; "ask" escalates to the user
+  // for approval on runtimes that support it (Claude), falling back to block
+  // elsewhere (Codex). Only meaningful for blocks with canBlock === true.
+  mode?: "block" | "ask";
 }
 
 export const ParamDefinitionSchema = z.object({
@@ -87,4 +91,5 @@ export const BuildingBlockSchema = z.object({
 export const HookEntrySchema = z.object({
   block: z.string(),
   params: z.record(z.unknown()).default({}),
+  mode: z.enum(["block", "ask"]).default("block"),
 });

--- a/src/core/harness-converter-v2.ts
+++ b/src/core/harness-converter-v2.ts
@@ -108,6 +108,7 @@ export async function harnessToMergedConfigV2(
         matcher: entry.matcher ?? "",
         description: `Catalog block: ${blockId}`,
         inline: catalogResult.scripts.get(entry.command),
+        mode: entry.mode ?? "block",
       };
 
       additionalHooks[field].push(hookDef);

--- a/src/core/merged-config.ts
+++ b/src/core/merged-config.ts
@@ -5,6 +5,9 @@ export interface HookDefinition {
   script?: string;
   inline?: string;
   variables?: Record<string, unknown>;
+  // "ask" escalates to the user instead of hard-blocking (Claude); defaults to
+  // "block". Threaded into the generated hook script's _emit_decision.
+  mode?: "block" | "ask";
 }
 
 export interface ClaudeMdSection {

--- a/src/generators/hooks.ts
+++ b/src/generators/hooks.ts
@@ -10,7 +10,7 @@ function shellSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function buildLoggerSnippet(event: string, projectDir?: string): string {
+function buildLoggerSnippet(event: string, projectDir?: string, mode: "block" | "ask" = "block"): string {
   const stateDir = projectDir
     ? `${projectDir}/${OMH_STATE_DIR}`
     : OMH_STATE_DIR;
@@ -19,6 +19,7 @@ _OMH_STATE_DIR=${shellSingleQuote(stateDir)}
 mkdir -p "$_OMH_STATE_DIR" 2>/dev/null || true
 _OMH_HOOK_NAME="$(basename "$0")"
 _OMH_EVENT="${event}"
+_OMH_DECISION_MODE="${mode}"
 _OMH_LOGGED=0
 _log_event() {
   # Build the JSONL record entirely through jq so every string field is
@@ -55,8 +56,24 @@ _log_event() {
 # via echo "{...}" — a file name or pattern containing a quote, backslash,
 # or newline would otherwise produce invalid JSON that the runtime cannot
 # parse as a block decision.
+#
+# In ask mode the same hook escalates to the user instead of hard-blocking,
+# but only on runtimes that understand a permissionDecision:"ask" response.
+# Claude's PreToolUse payload carries a transcript_path field; Codex's does
+# not. A runtime we cannot positively identify as Claude falls through to a
+# hard block, so a guardrail (e.g. TDD) is never silently downgraded to allow.
+# The two requirements (Claude=ask, Codex=block) cannot coexist in one JSON —
+# a legacy {decision:"block"} overrides permissionDecision:"ask" on Claude —
+# so we branch on the caller instead of emitting a combined object.
 _emit_decision() {
   local decision="\${1:-block}" reason="\${2:-}"
+  if [ "\${_OMH_DECISION_MODE:-block}" = "ask" ] && [ "$decision" = "block" ]; then
+    if printf '%s' "\${INPUT:-}" | jq -e 'has("transcript_path")' >/dev/null 2>&1; then
+      jq -cn --arg reason "$reason" --arg event "$_OMH_EVENT" \\
+        '{hookSpecificOutput:{hookEventName:$event,permissionDecision:"ask",permissionDecisionReason:$reason}}'
+      return 0
+    fi
+  fi
   jq -cn --arg decision "$decision" --arg reason "$reason" \\
     '{decision:$decision,reason:$reason}'
 }
@@ -64,8 +81,13 @@ trap '_OMH_EXIT_CODE=$?; if [ "$_OMH_LOGGED" -eq 0 ]; then if [ "$_OMH_EXIT_CODE
 # --- end logger ---`;
 }
 
-export function wrapWithLogger(script: string, event: string = "unknown", projectDir?: string): string {
-  const snippet = buildLoggerSnippet(event, projectDir);
+export function wrapWithLogger(
+  script: string,
+  event: string = "unknown",
+  projectDir?: string,
+  mode: "block" | "ask" = "block",
+): string {
+  const snippet = buildLoggerSnippet(event, projectDir, mode);
   if (script.includes("INPUT=$(cat)")) {
     return script.replace("INPUT=$(cat)", `INPUT=$(cat)\n\n${snippet}`);
   }
@@ -194,7 +216,7 @@ export async function generateHooks(options: GenerateHooksOptions): Promise<Hook
       event: hook.event,
       matcher: hook.matcher,
       scriptPath: join(hooksDir, scriptName),
-      wrappedScript: wrapWithLogger(hook.inline, hook.event, projectDir),
+      wrappedScript: wrapWithLogger(hook.inline, hook.event, projectDir, hook.mode ?? "block"),
     });
   }
 

--- a/tests/integration/ask-mode-decisions.test.ts
+++ b/tests/integration/ask-mode-decisions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+import { renderTemplate } from "../../src/catalog/template-engine.js";
+import { wrapWithLogger } from "../../src/generators/hooks.js";
+import { commandGuard } from "../../src/catalog/blocks/command-guard.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "omh-ask-mode-"));
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+function hasJq(): boolean {
+  try {
+    execSync("jq --version", { encoding: "utf-8", timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runScript(scriptPath: string, stdin: string): string {
+  try {
+    return execSync(`bash "${scriptPath}"`, {
+      input: stdin,
+      cwd: tmpDir,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+  } catch (e) {
+    return (e as { stdout?: string }).stdout ?? "";
+  }
+}
+
+// Claude PreToolUse payload includes a transcript_path field; Codex does not.
+// The ask-mode hook uses this to decide whether the runtime understands a
+// permissionDecision:"ask" escalation (Claude) or must hard-block (Codex).
+const CLAUDE_STDIN = JSON.stringify({
+  session_id: "s1",
+  transcript_path: "/tmp/x.jsonl",
+  hook_event_name: "PreToolUse",
+  tool_name: "Bash",
+  tool_input: { command: "rm -rf /" },
+});
+
+const CODEX_STDIN = JSON.stringify({
+  tool_name: "Bash",
+  tool_input: { command: "rm -rf /" },
+});
+
+async function buildScript(mode: "block" | "ask"): Promise<string> {
+  const rendered = renderTemplate(commandGuard.template, { patterns: ["rm -rf /"] });
+  const wrapped = wrapWithLogger(rendered, "PreToolUse", undefined, mode);
+  const scriptPath = join(tmpDir, `command-guard-${mode}.sh`);
+  await writeFile(scriptPath, wrapped, { mode: 0o755 });
+  return scriptPath;
+}
+
+describe("ask-mode decisions (runtime-detecting single script)", () => {
+  it("ask mode + Claude payload: emits permissionDecision=ask (no hard block)", async () => {
+    if (!hasJq()) return;
+    const scriptPath = await buildScript("ask");
+    const out = runScript(scriptPath, CLAUDE_STDIN);
+    const decision = JSON.parse(out.trim());
+    expect(decision.hookSpecificOutput?.permissionDecision).toBe("ask");
+    expect(decision.hookSpecificOutput?.hookEventName).toBe("PreToolUse");
+    expect(decision.hookSpecificOutput?.permissionDecisionReason).toContain("rm -rf /");
+    // Must NOT carry a legacy block, which would override ask on Claude.
+    expect(decision.decision).toBeUndefined();
+  });
+
+  it("ask mode + Codex payload: falls back to hard block (decision=block)", async () => {
+    if (!hasJq()) return;
+    const scriptPath = await buildScript("ask");
+    const out = runScript(scriptPath, CODEX_STDIN);
+    const decision = JSON.parse(out.trim());
+    expect(decision.decision).toBe("block");
+    expect(decision.reason).toContain("rm -rf /");
+    // No ask escalation for a runtime that does not understand it.
+    expect(decision.hookSpecificOutput?.permissionDecision).not.toBe("ask");
+  });
+
+  it("block mode (default): Claude payload still gets a hard block", async () => {
+    if (!hasJq()) return;
+    const scriptPath = await buildScript("block");
+    const out = runScript(scriptPath, CLAUDE_STDIN);
+    const decision = JSON.parse(out.trim());
+    expect(decision.decision).toBe("block");
+    expect(decision.hookSpecificOutput?.permissionDecision).toBeUndefined();
+  });
+
+  it("block mode (default): Codex payload gets a hard block", async () => {
+    if (!hasJq()) return;
+    const scriptPath = await buildScript("block");
+    const out = runScript(scriptPath, CODEX_STDIN);
+    const decision = JSON.parse(out.trim());
+    expect(decision.decision).toBe("block");
+  });
+});

--- a/tests/integration/ask-mode-decisions.test.ts
+++ b/tests/integration/ask-mode-decisions.test.ts
@@ -63,9 +63,11 @@ async function buildScript(mode: "block" | "ask"): Promise<string> {
   return scriptPath;
 }
 
-describe("ask-mode decisions (runtime-detecting single script)", () => {
+// jq is required by the generated hook scripts. When it is absent the whole
+// suite is reported as skipped (not silently passed), so a missing jq cannot
+// hide an ask/block regression behind a green check.
+describe.skipIf(!hasJq())("ask-mode decisions (runtime-detecting single script)", () => {
   it("ask mode + Claude payload: emits permissionDecision=ask (no hard block)", async () => {
-    if (!hasJq()) return;
     const scriptPath = await buildScript("ask");
     const out = runScript(scriptPath, CLAUDE_STDIN);
     const decision = JSON.parse(out.trim());
@@ -77,7 +79,6 @@ describe("ask-mode decisions (runtime-detecting single script)", () => {
   });
 
   it("ask mode + Codex payload: falls back to hard block (decision=block)", async () => {
-    if (!hasJq()) return;
     const scriptPath = await buildScript("ask");
     const out = runScript(scriptPath, CODEX_STDIN);
     const decision = JSON.parse(out.trim());
@@ -88,7 +89,6 @@ describe("ask-mode decisions (runtime-detecting single script)", () => {
   });
 
   it("block mode (default): Claude payload still gets a hard block", async () => {
-    if (!hasJq()) return;
     const scriptPath = await buildScript("block");
     const out = runScript(scriptPath, CLAUDE_STDIN);
     const decision = JSON.parse(out.trim());
@@ -97,7 +97,6 @@ describe("ask-mode decisions (runtime-detecting single script)", () => {
   });
 
   it("block mode (default): Codex payload gets a hard block", async () => {
-    if (!hasJq()) return;
     const scriptPath = await buildScript("block");
     const out = runScript(scriptPath, CODEX_STDIN);
     const decision = JSON.parse(out.trim());

--- a/tests/unit/catalog-converter.test.ts
+++ b/tests/unit/catalog-converter.test.ts
@@ -178,4 +178,25 @@ describe("convertHookEntries", () => {
     expect(result.hooksConfig["PostToolUse"]).toHaveLength(2);
     expect(result.errors.filter((e) => e.includes("Duplicate"))).toHaveLength(0);
   });
+
+  it("defaults mode to block when not specified", async () => {
+    registry.register(makeBlock({ id: "b", canBlock: true }));
+    const result = await convertHookEntries([{ block: "b", params: {} }], registry, projectDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.hooksConfig["PreToolUse"][0].mode).toBe("block");
+  });
+
+  it("propagates ask mode for a block that can block", async () => {
+    registry.register(makeBlock({ id: "b", canBlock: true }));
+    const result = await convertHookEntries([{ block: "b", params: {}, mode: "ask" }], registry, projectDir);
+    expect(result.errors).toHaveLength(0);
+    expect(result.hooksConfig["PreToolUse"][0].mode).toBe("ask");
+  });
+
+  it("rejects ask mode on a non-blocking block and falls back to block", async () => {
+    registry.register(makeBlock({ id: "b", canBlock: false }));
+    const result = await convertHookEntries([{ block: "b", params: {}, mode: "ask" }], registry, projectDir);
+    expect(result.hooksConfig["PreToolUse"][0].mode).toBe("block");
+    expect(result.errors.some((e) => e.includes("does not support ask mode"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## What

Adds an optional per-hook `mode: block | ask` to `harness.yaml`. In **ask mode** a blocking hook escalates to the user for approval instead of hard-blocking.

```yaml
hooks:
  - block: tdd-guard
    mode: ask   # ask for approval instead of hard-blocking
```

## Why runtime detection

A single generated `.omh/hooks/*.sh` is shared by **both** Claude and Codex. The two requirements cannot coexist in one decision JSON — a legacy `{decision:"block"}` overrides `permissionDecision:"ask"` on Claude (**verified via tmux POC**). So `_emit_decision` detects the caller from its stdin payload:

| Runtime | Detect by | ask behavior |
|---------|-----------|--------------|
| **Claude** | `transcript_path` present | native prompt (`permissionDecision:"ask"`) |
| **Codex / unknown** | no `transcript_path` | **hard block** (fallback — never silently "allow") |

This guarantees a guardrail like TDD is **never downgraded to allow** on a runtime that can't truly ask. Codex ask support is intentionally deferred until POC-verified (Codex's PreToolUse has no "ask"; it can only allow/deny/defer).

## Changes

- `types.ts` / schema: `HookEntry.mode` (default `block`).
- `converter.ts`: propagates mode; rejects `ask` on `canBlock:false` (reports + falls back to block).
- `merged-config.ts` / `harness-converter-v2.ts`: thread mode through `HookDefinition`.
- `hooks.ts`: `_emit_decision` runtime detection; `wrapWithLogger` bakes mode.
- Tests: `ask-mode-decisions` integration (4) + converter unit (3); README documents `mode`.

## Verification

- `npm run lint` clean, `npm test` → **921 passed**.
- POC (tmux): Claude shows native ask prompt; Pi equivalent confirmed; Codex ask ignored → fallback to block is the safe behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 훅 블록에 "ask" 모드 추가 - 하드 블로킹 대신 사용자 승인 요청으로 동작 가능

* **문서화**
  * harness.yaml 설정에서 `mode: block/ask` 옵션 사용 방법 문서화
  * 각 모드의 동작 방식 및 호환성 정보 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kyu1204/oh-my-harness/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->