### PR TITLE
release: v0.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.11.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.11.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.13.0

v0.12.0 이후 머지된 변경사항을 릴리즈합니다. 이 PR을 머지하면 `auto-release` 워크플로가 `v0.13.0` 태그·GitHub Release 생성 및 npm publish를 자동 수행합니다.

### Changes since v0.12.0
- **feat(hooks):** add `ask` mode for blocking hooks (runtime-detecting single script) — Claude는 네이티브 승인 프롬프트, Codex는 hard block 폴백 (#79)
- **fix(codex):** migrate deprecated `codex_hooks` feature flag to `hooks` (#78)
- **docs(readme):** fix PI emitter roadmap entry to reference the pi.dev agent (#77)

### Verification
- `npm run lint` (tsc --noEmit) ✅
- `npm test` — 91 files / 922 tests ✅
- 실제 Claude tmux 세션 통합 QA: ask 모드 네이티브 승인 프롬프트 → 승인 시 통과 / block 모드 즉시 차단 대조 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)