### PR TITLE
docs(readme): remove Cursor emitter from roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,6 @@ oh-my-harness/
 - [x] GitHub star prompt — first-time only
 - [x] Codex emitter — `AGENTS.md` + `.codex/hooks.json` + `.codex/config.toml`
 - [x] Unified `.omh/` layout — single source of truth for hooks & state across runtimes
-- [ ] Cursor (`.cursor/rules/`) emitter
 - [ ] Pi ([pi.dev](https://pi.dev)) emitter — generate harness config for the Pi coding agent
 - [x] `ask` mode — request approval before executing risky tools (Claude; Codex falls back to block)
 - [ ] Community harness.yaml registry — share and reuse configs


### PR DESCRIPTION
## Summary

로드맵에 남아 있던 **Cursor (`.cursor/rules/`) emitter** 항목을 제거합니다. Cursor emitter는 계획된 산출물이 아니며, 다음 emitter 타깃은 Pi emitter 하나로 정리됩니다.

- 제거: `- [ ] Cursor (.cursor/rules/) emitter` (roadmap)
- 유지: 인트로의 "Cursor needs `.cursorrules`" 문장은 문제 설명용 사실 진술이라 그대로 둠

🤖 Generated with [Claude Code](https://claude.com/claude-code)