### PR TITLE
release: v0.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.13.1

v0.13.0 이후 머지된 docs 변경을 배포합니다. 머지 시 `auto-release` 워크플로가 `v0.13.1` 태그·GitHub Release 생성 및 npm publish를 자동 수행합니다.

### Changes since v0.13.0
- **docs(readme):** remove Cursor emitter from roadmap (#81) — 다음 emitter 타깃을 Pi emitter 하나로 정리

### Verification
- `npm run lint` (tsc --noEmit) ✅
- `npm test` — 91 files / 922 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)