### PR TITLE
release: v0.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.14.0

v0.13.1 이후 머지된 변경을 배포합니다. 머지 시 `auto-release` 워크플로가 `v0.14.0` 태그·GitHub Release 생성 및 npm publish를 자동 수행합니다.

### Changes since v0.13.1
- **feat(pi):** add Pi ([pi.dev](https://pi.dev)) emitter — bridge extension (`.pi/extensions/omh-harness.ts`) that shells out to the same `.omh/hooks/*.sh`, mapping ask → `ctx.ui.select` and block → `{ block: true }` (#83)
- **fix(pi):** fail closed on hook execution failure + correct test regex (#83 review)

### Verification
- `npm run lint` (tsc --noEmit) ✅
- `npm test` — 945 tests ✅
- 실제 Pi 0.74.2 tmux 통합 QA ✅: 확장 자동 로드, ask 네이티브 승인 프롬프트→실행, block 즉시 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 패키지 버전을 0.14.0으로 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->