### PR TITLE
Clarify uninstall safety across hook emitters

### DIFF
--- a/.omc/plans/uninstall-command.md
+++ b/.omc/plans/uninstall-command.md
@@ -1,7 +1,7 @@
 # `omh uninstall` + 훅 병합/제거 안전화 작업 계획서
 
-작성: 2026-06-02 · 재작성: 2026-06-03  
-대상: 딥 리서치 #2(라이프사이클 공백) + 선재 버그(sync가 사용자 훅 clobber)  
+작성: 2026-06-02 · 재작성: 2026-06-04
+대상: 딥 리서치 #2(라이프사이클 공백) + 선재 버그(sync가 사용자 훅 clobber)
 관련: [[sync-check-drift]] 의 `plan/compute` 아키텍처 재사용. TDD + 실 tmux 통합 QA 필수.
 
 ---
@@ -37,6 +37,7 @@ oh-my-harness는 생성물을 여러 위치에 흩뿌리지만 이를 되돌리�
 1. Claude `settings.json`은 `permissions`는 `_ohMyHarness.managedPermissions`로 사용자 항목을 보존하지만, `hooks`는 추적 없이 통째 교체한다.
 2. Codex `.codex/hooks.json`도 sync 때 파일 전체를 재생성하므로, 사용자가 같은 파일에 직접 추가한 훅은 사라진다.
 3. uninstall이 이후 우리 훅을 제거하려 해도, sync 단계에서 이미 사용자 훅을 잃으면 복구할 방법이 없다.
+4. Codex `.codex/config.toml`은 사용자 설정과 OMH feature flags가 섞인 머지형 파일이다. uninstall 시 `[features].hooks/goals` 제거는 사용자가 직접 켠 값을 지우는 오탐이 될 수 있고, TOML parser round-trip은 in-file comments를 제거할 수 있다.
 
 ### 목표
 
@@ -44,6 +45,8 @@ oh-my-harness는 생성물을 여러 위치에 흩뿌리지만 이를 되돌리�
    - 생성물을 안전하게 제거한다.
    - 사용자 콘텐츠는 보존한다.
    - 기본 dry-run 친화적 출력 + 확인 후 실행을 제공한다.
+   - destructive flow이므로 plan/dry-run/confirm 출력에 **백업 후 실행 권장** 문구를 포함한다.
+   - 자동화 호출자를 위해 `--skip-backup-warning`으로 백업 경고만 숨길 수 있게 한다. `--yes`는 확인 프롬프트만 생략하며, 백업 경고 숨김은 `--skip-backup-warning`이 있을 때만 허용한다.
 2. Claude hooks 병합 수정
    - sync 시 `.omh/hooks`를 가리키지 않는 사용자 훅 엔트리를 보존한다.
    - `.omh/hooks`를 가리키는 기존 OMH 훅만 새 생성물로 교체한다.
@@ -53,6 +56,10 @@ oh-my-harness는 생성물을 여러 위치에 흩뿌리지만 이를 되돌리�
 4. Pi uninstall 안전성 보장
    - `.pi/extensions/omh-harness.ts`만 제거한다.
    - `.pi/extensions/custom.ts` 같은 사용자 확장은 보존한다.
+5. Codex TOML 사용자 콘텐츠 보존 강화
+   - `.codex/config.toml` dry-run에는 `[features].hooks/goals` 제거 예정과 “사용자가 직접 설정한 경우 복원이 필요할 수 있음”을 명시한다.
+   - `.codex/config.toml` 수정은 comment loss 가능성을 사용자에게 경고한다.
+   - T4에서 comment-preserving TOML 대안 또는 최소 변경 보존 전략을 평가/구현하는 명시 작업을 둔다.
 
 ### 완료 기준
 
@@ -63,6 +70,7 @@ oh-my-harness는 생성물을 여러 위치에 흩뿌리지만 이를 되돌리�
   - Codex 사용자 훅 케이스가 선택한 정책대로 동작
     - 병합형 선택 시: `.codex/hooks.json` 사용자 훅 보존
     - 전용 파일 선택 시: 문서와 dry-run 경고가 명확함
+  - Codex `.codex/config.toml` feature-key 오탐 가능성과 TOML comment-loss 경고가 dry-run에 표시됨
   - uninstall 후 생성물 제거, 사용자 콘텐츠 보존, `harness.yaml` 기본 보존
 
 ---
@@ -79,22 +87,24 @@ isOmhHookCommand(command, projectDir) === true
 
 true 조건:
 
-- command가 `.omh/hooks` 경로를 참조한다.
-- 절대경로/인용/`bash '<path>'` 형식을 robust하게 처리한다.
-- 가능하면 `projectDir/.omh/hooks` 하위 realpath로 확인한다.
+- command에서 실행 대상 script path를 추출한다. 지원 형식은 최소 `bash '<path>'`, `bash "<path>"`, unquoted absolute path, shell command 안의 quoted path다.
+- 추출한 path와 `projectDir/.omh/hooks`를 모두 `realpath`로 canonicalize한다.
+- hook script realpath가 `realpath(projectDir/.omh/hooks)`의 **strict descendant**일 때만 true다.
+- `projectDir/.omh/hooks` 자체가 없거나 realpath 확인에 실패하면 true로 추정하지 않고 false다.
 
 보수 원칙:
 
 - 불확실하면 사용자 훅으로 보고 보존한다.
-- command 문자열만으로 `.omh/hooks` 하위가 확실할 때만 제거/교체한다.
+- 문자열에 `.omh/hooks`가 포함되어도 canonical hooks dir 하위 realpath가 아니면 OMH 훅으로 보지 않는다.
+- path traversal(`../..`)이나 symlink가 프로젝트 밖을 가리키는 경우 false다.
 
 ### 2.2 파일별 소유권
 
 | 파일 | 소유권 | sync 전략 | uninstall 전략 |
 |---|---|---|---|
 | `.claude/settings.json` | 병합형 | 사용자 hooks/permissions/기타 키 보존, OMH hooks/permissions만 갱신 | OMH hooks/permissions/meta만 제거 |
-| `.codex/hooks.json` | **결정 필요** | 권장: 병합형. 최소안: OMH 전용 | 권장: OMH command만 제거. 최소안: 파일 삭제 |
-| `.codex/config.toml` | 병합형 | 사용자 테이블 보존, `[features].hooks/goals`만 보장 | OMH가 추가한 feature keys만 제거 |
+| `.codex/hooks.json` | **결정 필요** | 권장: 병합형. 최소안: OMH 전용 | 권장: OMH command만 제거. 최소안: 파일 삭제 + non-OMH 경고 |
+| `.codex/config.toml` | 병합형 | 사용자 테이블 보존, `[features].hooks/goals`만 보장 | OMH가 추가한 feature keys 제거 전 경고. 사용자 inline hooks/MCP 보존. comments 보존 전략 필요 |
 | `.pi/extensions/omh-harness.ts` | 전용 | 통째 생성/갱신 | 통째 삭제 |
 | `.pi/extensions/*.ts` 기타 | 사용자 | 건드리지 않음 | 보존 |
 
@@ -114,7 +124,7 @@ true 조건:
 
 | 경로 | 처리 |
 |---|---|
-| `.codex/hooks.json` | 정책 결정에 따름. 병합형 승격 시 통째 삭제 금지, OMH 훅만 제거. 전용 계약 유지 시 통째 삭제 |
+| `.codex/hooks.json` | 정책 결정에 따름. 병합형 승격 시 통째 삭제 금지, OMH 훅만 제거. 전용 계약 유지 시 통째 삭제하되 non-OMH command가 있으면 dry-run/실행 출력에 강한 경고 |
 
 ### B. 머지형 파일 — 외과적 제거
 
@@ -123,8 +133,8 @@ true 조건:
 | `CLAUDE.md` | managed section만 제거 | 사용자 본문 |
 | `AGENTS.md` | managed section만 제거 | 사용자 본문 |
 | `.claude/settings.json` | OMH permissions/hooks/meta만 제거 | 사용자 permissions/hooks/기타 키 |
-| `.codex/config.toml` | OMH feature keys + deprecated key만 제거 | inline hooks, MCP 서버, 사용자 TOML 설정 |
-| `.codex/hooks.json` | 병합형 선택 시 OMH command 엔트리만 제거 | 사용자 Codex hooks |
+| `.codex/config.toml` | OMH feature keys + deprecated key만 제거. 제거 전 feature-key 오탐 경고와 comment-loss 경고 표시 | inline hooks, MCP 서버, 사용자 TOML 설정, 가능하면 comments |
+| `.codex/hooks.json` | 병합형 선택 시 OMH command hook만 제거. event별 사용자 hook order 보존 | 사용자 Codex hooks |
 | `.gitignore` | `# oh-my-harness` section만 제거 | 사용자 라인 |
 
 ### C. 기본 보존
@@ -143,17 +153,43 @@ true 조건:
 ```ts
 computeUninstall(projectDir, opts) => UninstallPlan {
   delete: string[]
-  modify: { path: string; content: string }[]
+  modify: { path: string; content: string; backupPath?: string }[]
   removeDirs: string[]
   keptHarnessYaml: boolean
+  warnings: string[]
+  destructiveWarnings: string[]
+}
+
+applyUninstallPlan(plan, opts) => UninstallResult {
+  modified: string[]
+  deleted: string[]
+  removedDirs: string[]
+  restored: string[]
+  failed: { path: string; op: "modify" | "delete" | "removeDir" | "restore"; message: string }[]
   warnings: string[]
 }
 ```
 
-- `omh uninstall --dry-run`: 플랜만 출력, 쓰기 없음.
-- `omh uninstall`: 플랜 출력 → 확인 → 실행.
-- `omh uninstall --yes`: 확인 생략.
+- `omh uninstall --dry-run`: 플랜만 출력, 쓰기 없음. 항상 `백업 후 실행 권장`을 표시한다.
+- `omh uninstall`: 플랜 출력 → 백업 권장 표시 → 확인 → 실행.
+- `omh uninstall --yes`: 확인 프롬프트만 생략한다. 백업 권장은 계속 표시한다.
+- `omh uninstall --skip-backup-warning`: 백업 권장 문구를 숨긴다. `--yes`와 별개다.
 - `omh uninstall --purge`: `harness.yaml`까지 삭제.
+- `omh uninstall --continue-on-error`: 가능한 작업을 계속하고 post-run summary에 실패 목록을 남긴다. 기본은 stop-on-error.
+
+### 적용 순서와 부분 실패 복구
+
+1. **prepare backups**: modify 대상 원본을 임시 백업 파일에 저장한다.
+2. **modify**: 머지형 파일을 먼저 안전하게 수정한다. 실패하면 기본 정책은 즉시 중단하고 이미 수정된 파일을 백업에서 복원한다.
+3. **delete**: 전용 파일/디렉터리를 삭제한다.
+4. **removeDirs**: 빈 디렉터리만 마지막에 정리한다.
+5. **post-run summary**: 성공/실패/복원/잔여 파일을 모두 출력한다.
+
+정책:
+
+- 기본 `stop-on-error`: 첫 실패 시 중단, 수정된 머지형 파일은 restore 시도, 실패 상세 출력.
+- `--continue-on-error`: 각 op 실패를 `UninstallResult.failed`에 기록하고 다음 op 진행. modify 실패 시 해당 파일만 건너뛰며 delete/removeDirs는 계속 가능.
+- critical failure 후에는 “일부 파일이 제거되었고 일부는 남았음”을 명확히 출력하고 재실행/수동 복구 경로를 안내한다.
 
 ### 역-generator 모듈
 
@@ -174,7 +210,7 @@ computeUninstall(projectDir, opts) => UninstallPlan {
 - managed markdown section 유틸
 - settings managed permissions 메타
 - gitignore section header
-- TOML parser(`smol-toml`)
+- TOML parser(`smol-toml`) 또는 comment-preserving 대안
 
 ---
 
@@ -186,9 +222,11 @@ omh uninstall [options]
   --dry-run
   -y, --yes
   --purge
+  --skip-backup-warning
+  --continue-on-error
 ```
 
-기본 출력:
+기본 plan 출력은 dry-run과 실제 실행이 같은 renderer를 사용한다.
 
 ```text
 oh-my-harness uninstall plan
@@ -196,7 +234,19 @@ oh-my-harness uninstall plan
 - modify: M files
 - keep: harness.yaml
 - warnings: K
+
+Safety:
+- 백업 후 실행 권장: uninstall은 파일을 수정/삭제하는 파괴적 작업입니다.
+- .codex/config.toml: [features].hooks/goals 제거 예정. 사용자가 직접 설정한 값이면 복원이 필요할 수 있습니다.
+- .codex/config.toml: 수정 시 TOML in-file comments가 제거될 수 있습니다.
 ```
+
+출력 규칙:
+
+- `--dry-run`: 위 plan + `백업 후 실행 권장` + Codex hook/config warnings를 표시하고 종료한다.
+- `--yes`: 확인 프롬프트만 건너뛴다. `--skip-backup-warning` 없이는 백업 권장 문구를 표시한다.
+- `--skip-backup-warning`: 백업 권장 문구만 숨긴다. Codex data-loss 가능성 경고는 숨기지 않는다.
+- 실행 후 summary는 `modified/deleted/removedDirs/restored/failed/remaining`을 출력한다.
 
 Codex 정책별 출력:
 
@@ -213,12 +263,20 @@ Codex 정책별 출력:
 
 - `src/core/managed-hooks.ts` 또는 `src/core/uninstall.ts`에 공유 유틸 추가.
 - `isOmhHookCommand(command, projectDir)` 구현.
+- 구현 요구:
+  - command에서 후보 path를 추출한다.
+  - 후보 path와 `projectDir/.omh/hooks`를 realpath로 정규화한다.
+  - 후보 realpath가 canonical hooks dir의 strict descendant인지 확인한다.
+  - symlink가 프로젝트 밖을 가리키면 false다.
 - 테스트:
   - `bash '<project>/.omh/hooks/foo.sh'` true
   - quoted/unquoted true
+  - realpath-normalized path가 `projectDir/.omh/hooks` 내부면 true
   - `.omh/hooks` 바깥 경로 false
   - `node myhook.js`, `python3 ~/.codex/hooks/foo.py` false
-  - path traversal/유사 문자열은 false
+  - `../..` traversal로 프로젝트 밖 `.omh/hooks`를 가리키면 false
+  - symlink가 프로젝트 밖 script를 가리키면 false
+  - `.omh/hooks` 문자열만 포함된 non-path command는 false
 
 ### T1. Claude generate hooks 병합 — 선재 버그 수정
 
@@ -240,8 +298,10 @@ Codex 정책별 출력:
 
 - `src/generators/codex-config.ts`
   - 기존 `.codex/hooks.json`을 읽어 parse한다.
-  - OMH command만 제거한다.
-  - 사용자 hooks + 새 OMH hooks를 병합한다.
+  - Codex hook schema를 검증/정규화한다.
+  - event 값이 single object면 array로 정규화한다. 정규화 불가능한 scalar/unknown schema는 overwrite하지 않고 명확한 에러를 surface한다.
+  - 동일 event는 `사용자 hooks → 새 OMH hooks` 순서로 ordered array 병합한다.
+  - OMH command만 제거한 뒤 새 OMH hooks를 추가한다.
   - malformed JSON이면 overwrite하지 말고 에러를 surface한다.
 - `stripCodexHooksJson(json, projectDir)` 추가.
 - 테스트:
@@ -249,6 +309,10 @@ Codex 정책별 출력:
   - 이전 OMH 훅 교체
   - 사용자 inline `[hooks]` in `config.toml` 보존
   - malformed hooks.json에서 사용자 내용 보호를 위해 실패
+  - 사용자 event가 array이고 OMH event가 array일 때 순서 보존(user first, OMH second)
+  - 사용자 event가 single object일 때 array로 정규화 후 병합
+  - 동일 event에 여러 사용자 훅이 있을 때 원래 순서 유지
+  - future schema처럼 hooks event가 scalar/비객체/비배열이면 실패하고 overwrite 금지
 
 #### 최소안 B — `.codex/hooks.json` OMH 전용 계약 유지
 
@@ -276,6 +340,9 @@ Codex 정책별 출력:
   - OMH 부분만 제거
   - OMH만 있던 파일은 `null`
   - 마커/메타 없으면 보수적으로 보존
+  - `.codex/config.toml` inline `[hooks]`와 MCP server 보존
+  - `[features].hooks/goals` 제거 예정 warning 생성
+  - TOML comments 보존 전략이 구현된 경우 comments 유지, 구현 전이면 dry-run warning 존재
 
 ### T4. `computeUninstall` 플랜
 
@@ -285,6 +352,14 @@ Codex 정책별 출력:
   - `.pi/extensions/omh-harness.ts`
   - `.codex/hooks.json`은 정책에 따라 delete 또는 modify
 - 머지형 strip 결과를 `modify` 또는 `delete`로 반영.
+- destructive warning 수집:
+  - 백업 권장
+  - `.codex/config.toml` feature-key 오탐 가능성
+  - `.codex/config.toml` TOML comment-loss 가능성
+  - `.codex/hooks.json` 전용 계약 선택 시 non-OMH command 삭제 위험
+- comment-preserving TOML 대안 평가/구현:
+  - 우선 최소 변경 가능한 preservation strategy를 검토한다.
+  - parser round-trip이 불가피하면 dry-run/README에 comments 제거 가능성을 명시하고 테스트로 warning을 고정한다.
 - 빈 디렉터리 정리 후보:
   - `.pi/extensions`
   - `.pi`
@@ -293,23 +368,33 @@ Codex 정책별 출력:
 - `harness.yaml`은 기본 보존, `--purge`면 delete.
 - 테스트:
   - 합성 프로젝트에서 delete/modify/removeDirs 정확
+  - warnings/destructiveWarnings 정확
   - `--purge` 동작
   - 비-OMH 프로젝트 무해 동작
+  - 사용자가 직접 `[features].hooks/goals`를 둔 config에서 dry-run warning 생성
 
 ### T5. uninstall 실행기 + CLI
 
 - `src/cli/commands/uninstall.ts`
-  - plan 출력
+  - plan 출력: dry-run과 실제 실행이 같은 renderer 사용
+  - 백업 권장 출력 + `--skip-backup-warning`
   - dry-run
   - confirm prompt
   - `--yes`
+  - `--continue-on-error`
+  - modify backup 생성, 실패 시 restore
   - delete/modify/removeDirs 실행
+  - post-run summary 출력
 - CLI index 와이어링.
 - 테스트:
   - command 등록
   - dry-run은 쓰기 없음
-  - `--yes`는 실행
+  - dry-run에 `백업 후 실행 권장` 포함
+  - `--skip-backup-warning`은 백업 권장만 숨기고 Codex data-loss warning은 유지
+  - `--yes`는 confirm만 생략하고 백업 권장은 유지
   - confirm no는 실행 안 함
+  - modify 실패 시 stop-on-error + restore 시도 + failed summary
+  - `--continue-on-error`는 실패 기록 후 가능한 op 계속 진행
 
 ### T6. 안전장치
 
@@ -317,44 +402,80 @@ Codex 정책별 출력:
 - manifest 기반 삭제는 경로 검증.
 - `.omh/hooks` 경로 식별이 애매하면 사용자 훅으로 보존.
 - `.pi/extensions`와 `.codex`는 비어 있을 때만 디렉터리 삭제.
-- `.codex/config.toml`에서 사용자가 직접 `hooks = true`/`goals = true`를 원했을 가능성은 추적 불가. uninstall은 OMH가 추가한 feature로 보고 제거하되, 다른 `[features]` 키는 보존한다.
+- `.codex/config.toml`에서 사용자가 직접 `hooks = true`/`goals = true`를 원했을 가능성은 추적 불가. uninstall은 OMH가 추가한 feature로 보고 제거하되, dry-run/실행 출력에 복원 필요 가능성을 명시하고 다른 `[features]` 키는 보존한다.
+- `.codex/config.toml` 수정은 comments 제거 가능성을 경고하고, comment-preserving 전략이 구현될 때까지 사용자 콘텐츠 손실 리스크로 관리한다.
 
 ### T7. 실 tmux 통합 QA
 
-빌드된 `omh`로 임시 프로젝트에서 수행한다.
+빌드된 `omh`로 임시 프로젝트에서 수행한다. 각 검증은 pass/fail 기준이 모호하지 않게 아래 형식을 따른다.
 
 1. `omh sync`
 2. 사용자 콘텐츠 추가
    - `CLAUDE.md` 사용자 본문
-   - `.claude/settings.json` 사용자 permission + 사용자 hook
-   - `.codex/config.toml` inline `[hooks]` + MCP server
-   - 권장안 A 선택 시 `.codex/hooks.json` 사용자 hook
+   - `.claude/settings.json` 사용자 permission + 사용자 hook(`custom-hook.sh`)
+   - `.codex/config.toml` inline `[hooks]` + MCP server + 사용자가 직접 둔 `[features].hooks/goals`
+   - 권장안 A 선택 시 `.codex/hooks.json` 사용자 hook(`python3 user-codex-hook.py`)
    - `.pi/extensions/custom.ts`
 3. `omh sync` 재실행
-4. 검증
-   - Claude 사용자 hook 보존
-   - Codex 사용자 hook 정책대로 보존/경고
-   - Pi custom extension 보존
+4. sync 후 보존 검증
+   - 검증 항목: Claude 사용자 hook 보존
+     - 검증 방법: `.claude/settings.json`을 열어 `hooks` 배열/객체를 확인한다.
+     - 예상 결과: 사용자 `custom-hook.sh` entry가 존재하고 OMH `.omh/hooks/*.sh` entry도 함께 존재한다.
+   - 검증 항목: Codex 사용자 hook 보존/경고
+     - 검증 방법: `.codex/hooks.json`과 `.codex/config.toml`을 확인한다.
+     - 예상 결과: 권장안 A면 `python3 user-codex-hook.py`가 보존되고 OMH hook은 뒤에 병합된다. 최소안 B면 sync/dry-run 문서와 경고가 `.codex/hooks.json` 전용 계약을 명확히 알린다. `.codex/config.toml` inline `[hooks]`와 MCP server는 항상 보존된다.
+   - 검증 항목: Pi custom extension 보존
+     - 검증 방법: `.pi/extensions/custom.ts` 내용을 sync 전후로 비교한다.
+     - 예상 결과: 파일이 존재하고 내용이 변경되지 않는다. `.pi/extensions/omh-harness.ts`는 OMH bridge로 생성/갱신된다.
 5. `omh uninstall --dry-run`
-6. `omh uninstall -y`
-7. 검증
-   - `.omh` 제거
-   - `.pi/extensions/omh-harness.ts` 제거
-   - `.pi/extensions/custom.ts` 보존
-   - `CLAUDE.md`/`AGENTS.md` 사용자 본문 보존
-   - `.claude/settings.json` 사용자 permission/hook 보존
-   - `.codex/config.toml` 사용자 inline hooks/MCP 보존
-   - `harness.yaml` 보존
-8. `omh uninstall -y --purge` 1회 추가 검증
-   - `harness.yaml` 삭제
+6. dry-run 출력 검증
+   - 검증 항목: destructive backup warning
+     - 검증 방법: stdout을 확인한다.
+     - 예상 결과: `백업 후 실행 권장`이 포함된다.
+   - 검증 항목: Codex feature-key 오탐 경고
+     - 검증 방법: stdout warnings를 확인한다.
+     - 예상 결과: `.codex/config.toml`의 `[features].hooks/goals` 제거 예정과 사용자가 직접 설정한 경우 복원이 필요할 수 있음이 표시된다.
+   - 검증 항목: TOML comment-loss 경고
+     - 검증 방법: stdout warnings를 확인한다.
+     - 예상 결과: `.codex/config.toml` 수정 시 in-file comments가 제거될 수 있음이 표시된다.
+7. `omh uninstall -y`
+8. uninstall 후 파일시스템 검증
+   - 검증 항목: OMH 전용 생성물 제거
+     - 검증 방법: `find . -maxdepth 3` 또는 `test ! -e`로 확인한다.
+     - 예상 결과: `.omh`와 `.pi/extensions/omh-harness.ts`가 없다.
+   - 검증 항목: Pi 사용자 확장 보존
+     - 검증 방법: `.pi/extensions/custom.ts` 존재/내용을 확인한다.
+     - 예상 결과: 파일이 존재하고 uninstall 전 사용자 내용과 같다.
+   - 검증 항목: Markdown 사용자 본문 보존
+     - 검증 방법: `CLAUDE.md`/`AGENTS.md` 내용을 확인한다.
+     - 예상 결과: 사용자 본문은 남고 OMH managed section은 제거된다.
+   - 검증 항목: Claude settings 사용자 콘텐츠 보존
+     - 검증 방법: `.claude/settings.json`을 JSON parse해 permissions/hooks/기타 키를 확인한다.
+     - 예상 결과: 사용자 permission과 `custom-hook.sh`는 남고 OMH permission/hook/meta는 제거된다.
+   - 검증 항목: Codex config 사용자 콘텐츠 보존
+     - 검증 방법: `.codex/config.toml`을 확인한다.
+     - 예상 결과: inline `[hooks]`, MCP server, 사용자 다른 keys는 남는다. `[features].hooks/goals` 제거 여부는 dry-run warning과 일치한다.
+   - 검증 항목: harness.yaml 기본 보존
+     - 검증 방법: `test -f harness.yaml`.
+     - 예상 결과: 파일이 존재한다.
+9. `omh uninstall -y --purge` 1회 추가 검증
+   - 검증 항목: purge deletes harness source
+     - 검증 방법: `test ! -e harness.yaml`.
+     - 예상 결과: `harness.yaml`이 삭제된다.
+10. 실패/복구 검증
+    - 검증 항목: modify 실패 시 restore/post-run summary
+      - 검증 방법: 임시 프로젝트에서 대상 파일 권한 또는 mock fs로 modify 실패를 유발한다.
+      - 예상 결과: 기본 모드는 중단 + 가능한 restore + failed summary를 출력한다. `--continue-on-error`는 실패를 기록하고 가능한 후속 op를 계속한다.
 
 ### T8. 문서
 
 - README:
   - `omh uninstall` 사용법
-  - `--dry-run`, `--yes`, `--purge`
+  - `--dry-run`, `--yes`, `--purge`, `--skip-backup-warning`, `--continue-on-error`
   - uninstall vs purge
+  - 백업 권장과 부분 실패 복구 정책
   - Claude/Codex/Pi 훅 보존 정책
+  - Codex `.codex/config.toml` feature-key 제거/주석 손실 가능성
 - Codex 정책 문서화:
   - 권장안 A면 `.codex/hooks.json` 사용자 훅 보존 명시
   - 최소안 B면 `.codex/hooks.json`은 OMH 전용이고 사용자 훅은 inline `[hooks]` 또는 user-level hooks로 안내
@@ -365,9 +486,9 @@ Codex 정책별 출력:
 
 | 레벨 | 범위 |
 |---|---|
-| 단위 | `isOmhHookCommand`, strip 유틸, Claude/Codex hook merge |
-| 통합 | `computeUninstall` 플랜, 실행 후 디스크 상태 |
-| E2E(tmux) | sync → 사용자 편집 → sync → uninstall → 보존/제거 검증 |
+| 단위 | `isOmhHookCommand`, realpath/symlink/traversal, strip 유틸, Claude/Codex hook merge, Codex schema normalization |
+| 통합 | `computeUninstall` 플랜, warning rendering, apply order, restore/continue-on-error, 실행 후 디스크 상태 |
+| E2E(tmux) | sync → 사용자 편집 → sync → dry-run warning 검증 → uninstall → 보존/제거/복구 검증 |
 
 완료: `npm run lint` + `npm test` + T7 통과.
 
@@ -380,20 +501,32 @@ Codex 정책별 출력:
    - 사용자 안전 우선이면 병합형 승격(A).
    - 구현 단순성과 기존 가정 유지면 전용 계약(B), 대신 경고/문서가 필수.
 2. **사용자 콘텐츠 오삭제**
-   - 모든 제거는 마커/메타/`.omh/hooks` 경로 기반.
+   - 모든 제거는 마커/메타/`.omh/hooks` canonical realpath 기반.
    - 불확실하면 보존.
 3. **한 matcher group에 사용자 hook과 OMH hook이 섞인 경우**
    - hook command 단위 partition 필요.
    - entry 단위 삭제만 하면 사용자 hook까지 지울 수 있다.
-4. **Codex TOML 주석 손실**
-   - 기존 코드의 알려진 trade-off.
-   - uninstall에서도 TOML parser round-trip 사용 시 주석 손실 가능. 문서화 또는 regex-free 대안 검토.
-5. **Pi generated file 직접 편집**
+4. **OMH hook path traversal/symlink bypass**
+   - 문자열 매칭만으로 `.omh/hooks`를 판정하면 프로젝트 밖 script를 OMH 소유로 오인할 수 있다.
+   - `realpath(projectDir/.omh/hooks)` strict descendant 검증과 symlink-outside false 테스트가 필수다.
+5. **Codex TOML 주석 손실 — 높은 우선순위 사용자 콘텐츠 리스크**
+   - 기존 parser round-trip은 comments를 보존하지 않는다.
+   - uninstall dry-run은 `.codex/config.toml` 수정 시 in-file comments가 제거될 수 있음을 경고해야 한다.
+   - T4에서 comment-preserving TOML 대안 또는 최소 변경 preservation strategy를 평가/구현한다.
+6. **Codex `[features].hooks/goals` 사용자 설정 오탐**
+   - 현재 메타가 없어 OMH가 추가한 값과 사용자가 직접 설정한 값을 구분할 수 없다.
+   - dry-run은 제거 예정과 복원 필요 가능성을 명시해야 한다.
+   - T7에는 사용자가 직접 설정한 feature keys 케이스를 포함한다.
+7. **부분 실패 시 복구 전략**
+   - modify → delete → removeDirs 순서와 modify backup/restore가 필요하다.
+   - post-run summary는 성공/실패/복원/잔여 파일을 명확히 보여야 한다.
+   - 기본은 stop-on-error, 자동화는 `--continue-on-error`를 선택할 수 있다.
+8. **Pi generated file 직접 편집**
    - `.pi/extensions/omh-harness.ts`는 전용 파일로 명시.
    - 사용자 커스터마이징은 별도 `.pi/extensions/*.ts` 파일로 안내.
-6. **manifest 없는 레거시 프로젝트**
+9. **manifest 없는 레거시 프로젝트**
    - 마커/경로 기반 best-effort 제거.
-7. **명령 이름**
+10. **명령 이름**
    - `uninstall` 유지 권장. `clean`은 범위가 모호하고 `purge`와 혼동 가능.
 
 ---
@@ -411,12 +544,14 @@ Codex 정책별 출력:
 
 - strip 유틸
 - `computeUninstall`
+- destructive warning renderer
+- 부분 실패/복구 전략
 - 플랜 테스트
 
 ### PR-3 — CLI + 문서 + E2E
 
 - `omh uninstall` command
-- dry-run/confirm/yes/purge
+- dry-run/confirm/yes/purge/skip-backup-warning/continue-on-error
 - README
 - tmux 통합 QA
 

--- a/.omc/plans/uninstall-command.md
+++ b/.omc/plans/uninstall-command.md
@@ -1,0 +1,423 @@
+# `omh uninstall` + 훅 병합/제거 안전화 작업 계획서
+
+작성: 2026-06-02 · 재작성: 2026-06-03  
+대상: 딥 리서치 #2(라이프사이클 공백) + 선재 버그(sync가 사용자 훅 clobber)  
+관련: [[sync-check-drift]] 의 `plan/compute` 아키텍처 재사용. TDD + 실 tmux 통합 QA 필수.
+
+---
+
+## 0. 2026-06-03 재검증 요약 — Claude만의 문제가 아님
+
+Claude의 `.claude/settings.json`만 문제가 아니라, **Codex `.codex/hooks.json`도 같은 종류의 사용자 훅 clobber 위험이 있다.** Pi는 현재 생성 구조상 단일 전용 확장 파일만 덮어쓰므로 같은 수준의 병합 문제는 낮다.
+
+| 대상 | sync 시 사용자 훅 clobber | uninstall 시 사용자 훅 삭제 | 결론 |
+|---|---:|---:|---|
+| Claude `.claude/settings.json` | 있음 | 있음 | 기존 계획대로 병합/선별 제거 필수 |
+| Codex `.codex/hooks.json` | **있음** | **있음** | 전용 파일 계약으로 둘지, 병합형으로 승격할지 결정 필요 |
+| Codex `.codex/config.toml` inline `[hooks]` | 낮음 | 낮음 | 현재 TOML 병합이 사용자 inline hooks·테이블을 보존함 |
+| Pi `.pi/extensions/omh-harness.ts` | 같은 파일 직접 편집 시만 있음 | 같은 파일 직접 편집 시만 있음 | OMH 전용 generated file 취급이 타당 |
+| Pi `.pi/extensions/*.ts` 기타 파일 | 없음 | 없음 | 사용자 확장 보존, 빈 디렉터리만 정리 |
+
+### 근거
+
+- Claude: `src/generators/settings.ts`가 기존 settings를 spread한 뒤 `hooks: hooksOutput.hooksConfig`로 `hooks` 키를 통째 교체한다.
+- Codex: `src/generators/codex-config.ts`가 `.codex/hooks.json`을 `JSON.stringify(codexHooks)`로 통째 재작성한다. 기존 `.codex/hooks.json`의 사용자 훅은 보존되지 않는다.
+- Codex `config.toml`: `buildCodexConfigToml()`은 기존 TOML을 parse 후 `[features]`만 갱신하므로 inline `[hooks]`, MCP 서버 등 사용자 테이블은 보존된다. 단, TOML 주석은 round-trip 과정에서 사라진다.
+- Codex 공식 문서 기준, Codex는 `hooks.json`과 inline `[hooks]` tables를 모두 훅 소스로 인정하고 여러 훅 소스를 함께 로드한다. 따라서 사용자가 project-local `.codex/hooks.json`에 직접 훅을 두는 것도 정상 사용 케이스다.
+- Pi: `src/generators/pi-extension.ts`는 `.pi/extensions/omh-harness.ts`만 생성한다. 다른 `.pi/extensions/*.ts` 파일은 건드리지 않는다.
+
+---
+
+## 1. 문제 / 목표
+
+oh-my-harness는 생성물을 여러 위치에 흩뿌리지만 이를 되돌리는 명령이 없다. 사용자는 수동으로 삭제해야 하고, 특히 **머지형 파일**은 사용자 콘텐츠와 OMH 생성물이 섞여 있어 무차별 삭제가 위험하다.
+
+추가로 발견된 선재 버그는 더 중요하다.
+
+1. Claude `settings.json`은 `permissions`는 `_ohMyHarness.managedPermissions`로 사용자 항목을 보존하지만, `hooks`는 추적 없이 통째 교체한다.
+2. Codex `.codex/hooks.json`도 sync 때 파일 전체를 재생성하므로, 사용자가 같은 파일에 직접 추가한 훅은 사라진다.
+3. uninstall이 이후 우리 훅을 제거하려 해도, sync 단계에서 이미 사용자 훅을 잃으면 복구할 방법이 없다.
+
+### 목표
+
+1. `omh uninstall` 추가
+   - 생성물을 안전하게 제거한다.
+   - 사용자 콘텐츠는 보존한다.
+   - 기본 dry-run 친화적 출력 + 확인 후 실행을 제공한다.
+2. Claude hooks 병합 수정
+   - sync 시 `.omh/hooks`를 가리키지 않는 사용자 훅 엔트리를 보존한다.
+   - `.omh/hooks`를 가리키는 기존 OMH 훅만 새 생성물로 교체한다.
+3. Codex hooks 소유권 결정 및 구현
+   - 권장: `.codex/hooks.json`도 병합형으로 승격해 사용자 훅 보존.
+   - 최소안: `.codex/hooks.json`을 OMH 전용 파일로 명시하고, 사용자 Codex 훅은 `.codex/config.toml` inline `[hooks]` 또는 `~/.codex/hooks.json`에 두도록 문서화.
+4. Pi uninstall 안전성 보장
+   - `.pi/extensions/omh-harness.ts`만 제거한다.
+   - `.pi/extensions/custom.ts` 같은 사용자 확장은 보존한다.
+
+### 완료 기준
+
+- lint green
+- 전체 test green
+- 실 tmux 통합 QA 통과
+  - Claude 사용자 훅이 있는 `settings.json`에서 `sync` 후 사용자 훅 보존
+  - Codex 사용자 훅 케이스가 선택한 정책대로 동작
+    - 병합형 선택 시: `.codex/hooks.json` 사용자 훅 보존
+    - 전용 파일 선택 시: 문서와 dry-run 경고가 명확함
+  - uninstall 후 생성물 제거, 사용자 콘텐츠 보존, `harness.yaml` 기본 보존
+
+---
+
+## 2. 훅 소유권 원칙
+
+### 2.1 OMH 훅 식별 기준
+
+OMH가 만든 runtime hook command는 전부 생성된 `.omh/hooks/*.sh`를 실행한다. 따라서 다음 기준으로 OMH 훅을 식별한다.
+
+```ts
+isOmhHookCommand(command, projectDir) === true
+```
+
+true 조건:
+
+- command가 `.omh/hooks` 경로를 참조한다.
+- 절대경로/인용/`bash '<path>'` 형식을 robust하게 처리한다.
+- 가능하면 `projectDir/.omh/hooks` 하위 realpath로 확인한다.
+
+보수 원칙:
+
+- 불확실하면 사용자 훅으로 보고 보존한다.
+- command 문자열만으로 `.omh/hooks` 하위가 확실할 때만 제거/교체한다.
+
+### 2.2 파일별 소유권
+
+| 파일 | 소유권 | sync 전략 | uninstall 전략 |
+|---|---|---|---|
+| `.claude/settings.json` | 병합형 | 사용자 hooks/permissions/기타 키 보존, OMH hooks/permissions만 갱신 | OMH hooks/permissions/meta만 제거 |
+| `.codex/hooks.json` | **결정 필요** | 권장: 병합형. 최소안: OMH 전용 | 권장: OMH command만 제거. 최소안: 파일 삭제 |
+| `.codex/config.toml` | 병합형 | 사용자 테이블 보존, `[features].hooks/goals`만 보장 | OMH가 추가한 feature keys만 제거 |
+| `.pi/extensions/omh-harness.ts` | 전용 | 통째 생성/갱신 | 통째 삭제 |
+| `.pi/extensions/*.ts` 기타 | 사용자 | 건드리지 않음 | 보존 |
+
+---
+
+## 3. 제거 대상 분류
+
+### A. 전용 파일/디렉터리 — 통째 삭제
+
+| 경로 | 비고 |
+|---|---|
+| `.omh/` | hooks/, state/, manifest.json 전부 OMH 소유 |
+| `.claude/oh-my-harness.json` | OMH 상태 파일 |
+| `.pi/extensions/omh-harness.ts` | OMH Pi bridge 전용 파일 |
+
+조건부 전용:
+
+| 경로 | 처리 |
+|---|---|
+| `.codex/hooks.json` | 정책 결정에 따름. 병합형 승격 시 통째 삭제 금지, OMH 훅만 제거. 전용 계약 유지 시 통째 삭제 |
+
+### B. 머지형 파일 — 외과적 제거
+
+| 경로 | 제거 방법 | 보존 |
+|---|---|---|
+| `CLAUDE.md` | managed section만 제거 | 사용자 본문 |
+| `AGENTS.md` | managed section만 제거 | 사용자 본문 |
+| `.claude/settings.json` | OMH permissions/hooks/meta만 제거 | 사용자 permissions/hooks/기타 키 |
+| `.codex/config.toml` | OMH feature keys + deprecated key만 제거 | inline hooks, MCP 서버, 사용자 TOML 설정 |
+| `.codex/hooks.json` | 병합형 선택 시 OMH command 엔트리만 제거 | 사용자 Codex hooks |
+| `.gitignore` | `# oh-my-harness` section만 제거 | 사용자 라인 |
+
+### C. 기본 보존
+
+- `harness.yaml`: 사용자 소스. 기본 보존, `--purge`로만 삭제.
+- `.pi/extensions`의 사용자 확장 파일.
+- `.codex/config.toml`의 inline `[hooks]`와 사용자 설정.
+- 머지형 파일이 OMH 제거 후 빈 내용이면 파일 자체 삭제, 아니면 stripped 콘텐츠 기록.
+
+---
+
+## 4. 아키텍처 — plan/compute 재사용
+
+[[sync-check-drift]]에서 만든 패턴을 대칭으로 적용한다.
+
+```ts
+computeUninstall(projectDir, opts) => UninstallPlan {
+  delete: string[]
+  modify: { path: string; content: string }[]
+  removeDirs: string[]
+  keptHarnessYaml: boolean
+  warnings: string[]
+}
+```
+
+- `omh uninstall --dry-run`: 플랜만 출력, 쓰기 없음.
+- `omh uninstall`: 플랜 출력 → 확인 → 실행.
+- `omh uninstall --yes`: 확인 생략.
+- `omh uninstall --purge`: `harness.yaml`까지 삭제.
+
+### 역-generator 모듈
+
+`src/core/uninstall.ts`
+
+순수 함수 중심:
+
+- `isOmhHookCommand(command, projectDir)`
+- `stripManagedMarkdown(content)`
+- `stripClaudeSettings(json, projectDir)`
+- `stripCodexHooksJson(json, projectDir)` — 병합형 선택 시
+- `stripCodexConfigToml(toml)`
+- `stripGitignoreSection(content)`
+- `computeUninstall(projectDir, opts)`
+
+기존 유틸 재사용:
+
+- managed markdown section 유틸
+- settings managed permissions 메타
+- gitignore section header
+- TOML parser(`smol-toml`)
+
+---
+
+## 5. 명령 표면
+
+```bash
+omh uninstall [options]
+  -d, --project-dir <dir>
+  --dry-run
+  -y, --yes
+  --purge
+```
+
+기본 출력:
+
+```text
+oh-my-harness uninstall plan
+- delete: N files/directories
+- modify: M files
+- keep: harness.yaml
+- warnings: K
+```
+
+Codex 정책별 출력:
+
+- 병합형 선택 시: `.codex/hooks.json`: remove OMH hook entries, keep user entries.
+- 전용 계약 유지 시: `.codex/hooks.json`: delete whole file; warn if file contains non-OMH hook commands.
+
+---
+
+## 6. 작업 분해 — TDD 순서
+
+> 편집-시점 tdd-guard 활성. 소스 편집 전 대응 테스트 먼저 작성한다.
+
+### T0. 훅 소유권 유틸 추가
+
+- `src/core/managed-hooks.ts` 또는 `src/core/uninstall.ts`에 공유 유틸 추가.
+- `isOmhHookCommand(command, projectDir)` 구현.
+- 테스트:
+  - `bash '<project>/.omh/hooks/foo.sh'` true
+  - quoted/unquoted true
+  - `.omh/hooks` 바깥 경로 false
+  - `node myhook.js`, `python3 ~/.codex/hooks/foo.py` false
+  - path traversal/유사 문자열은 false
+
+### T1. Claude generate hooks 병합 — 선재 버그 수정
+
+- `src/generators/settings.ts`
+  - 기존 `hooks: hooksOutput.hooksConfig` 통째 교체 제거.
+  - 기존 `settings.hooks`를 event별로 순회한다.
+  - 각 matcher entry의 hook command 중 OMH command만 제거한다.
+  - 남은 사용자 entry + 새 OMH entry를 합친다.
+  - 빈 event는 제거한다.
+- 테스트:
+  - 사용자 훅 보존 + OMH 훅 추가
+  - 재sync 시 이전 OMH 훅은 중복 없이 교체
+  - 사용자 훅 없음 케이스 기존 동작 유지
+  - matcher group 안에 사용자 hook과 OMH hook이 섞이면 사용자 hook만 보존
+
+### T2. Codex hooks 정책 구현
+
+#### 권장안 A — `.codex/hooks.json` 병합형 승격
+
+- `src/generators/codex-config.ts`
+  - 기존 `.codex/hooks.json`을 읽어 parse한다.
+  - OMH command만 제거한다.
+  - 사용자 hooks + 새 OMH hooks를 병합한다.
+  - malformed JSON이면 overwrite하지 말고 에러를 surface한다.
+- `stripCodexHooksJson(json, projectDir)` 추가.
+- 테스트:
+  - 사용자 `.codex/hooks.json` 훅 보존
+  - 이전 OMH 훅 교체
+  - 사용자 inline `[hooks]` in `config.toml` 보존
+  - malformed hooks.json에서 사용자 내용 보호를 위해 실패
+
+#### 최소안 B — `.codex/hooks.json` OMH 전용 계약 유지
+
+- 코드 변경 최소화.
+- uninstall dry-run에서 non-OMH command가 발견되면 강한 경고.
+- README에 사용자 Codex 훅 위치를 명시:
+  - project-local inline `[hooks]` in `.codex/config.toml`
+  - user-level `~/.codex/hooks.json`
+- 테스트:
+  - uninstall이 `.codex/hooks.json` 전체 삭제
+  - non-OMH command 포함 시 warning 출력
+
+> 추천은 A. Codex 공식 문서상 `.codex/hooks.json`도 정상 사용자 훅 표면이므로, Claude와 같은 보존 원칙을 적용하는 편이 안전하다.
+
+### T3. 머지형 외과 제거 유틸
+
+- `src/core/uninstall.ts`
+  - `stripManagedMarkdown(content) => string | null`
+  - `stripClaudeSettings(json, projectDir) => object | null`
+  - `stripCodexConfigToml(toml) => string | null`
+  - `stripCodexHooksJson(json, projectDir) => object | null` — 권장안 A 선택 시
+  - `stripGitignoreSection(content) => string | null`
+- 테스트:
+  - 사용자 본문/permission/hook/TOML table/gitignore line 보존
+  - OMH 부분만 제거
+  - OMH만 있던 파일은 `null`
+  - 마커/메타 없으면 보수적으로 보존
+
+### T4. `computeUninstall` 플랜
+
+- 전용 경로 수집:
+  - `.omh`
+  - `.claude/oh-my-harness.json`
+  - `.pi/extensions/omh-harness.ts`
+  - `.codex/hooks.json`은 정책에 따라 delete 또는 modify
+- 머지형 strip 결과를 `modify` 또는 `delete`로 반영.
+- 빈 디렉터리 정리 후보:
+  - `.pi/extensions`
+  - `.pi`
+  - `.codex`는 사용자 `config.toml`/기타 파일이 있으면 보존
+  - `.claude`는 사용자 파일이 있으면 보존
+- `harness.yaml`은 기본 보존, `--purge`면 delete.
+- 테스트:
+  - 합성 프로젝트에서 delete/modify/removeDirs 정확
+  - `--purge` 동작
+  - 비-OMH 프로젝트 무해 동작
+
+### T5. uninstall 실행기 + CLI
+
+- `src/cli/commands/uninstall.ts`
+  - plan 출력
+  - dry-run
+  - confirm prompt
+  - `--yes`
+  - delete/modify/removeDirs 실행
+- CLI index 와이어링.
+- 테스트:
+  - command 등록
+  - dry-run은 쓰기 없음
+  - `--yes`는 실행
+  - confirm no는 실행 안 함
+
+### T6. 안전장치
+
+- malformed JSON/TOML은 overwrite/delete하지 않고 경고 또는 실패.
+- manifest 기반 삭제는 경로 검증.
+- `.omh/hooks` 경로 식별이 애매하면 사용자 훅으로 보존.
+- `.pi/extensions`와 `.codex`는 비어 있을 때만 디렉터리 삭제.
+- `.codex/config.toml`에서 사용자가 직접 `hooks = true`/`goals = true`를 원했을 가능성은 추적 불가. uninstall은 OMH가 추가한 feature로 보고 제거하되, 다른 `[features]` 키는 보존한다.
+
+### T7. 실 tmux 통합 QA
+
+빌드된 `omh`로 임시 프로젝트에서 수행한다.
+
+1. `omh sync`
+2. 사용자 콘텐츠 추가
+   - `CLAUDE.md` 사용자 본문
+   - `.claude/settings.json` 사용자 permission + 사용자 hook
+   - `.codex/config.toml` inline `[hooks]` + MCP server
+   - 권장안 A 선택 시 `.codex/hooks.json` 사용자 hook
+   - `.pi/extensions/custom.ts`
+3. `omh sync` 재실행
+4. 검증
+   - Claude 사용자 hook 보존
+   - Codex 사용자 hook 정책대로 보존/경고
+   - Pi custom extension 보존
+5. `omh uninstall --dry-run`
+6. `omh uninstall -y`
+7. 검증
+   - `.omh` 제거
+   - `.pi/extensions/omh-harness.ts` 제거
+   - `.pi/extensions/custom.ts` 보존
+   - `CLAUDE.md`/`AGENTS.md` 사용자 본문 보존
+   - `.claude/settings.json` 사용자 permission/hook 보존
+   - `.codex/config.toml` 사용자 inline hooks/MCP 보존
+   - `harness.yaml` 보존
+8. `omh uninstall -y --purge` 1회 추가 검증
+   - `harness.yaml` 삭제
+
+### T8. 문서
+
+- README:
+  - `omh uninstall` 사용법
+  - `--dry-run`, `--yes`, `--purge`
+  - uninstall vs purge
+  - Claude/Codex/Pi 훅 보존 정책
+- Codex 정책 문서화:
+  - 권장안 A면 `.codex/hooks.json` 사용자 훅 보존 명시
+  - 최소안 B면 `.codex/hooks.json`은 OMH 전용이고 사용자 훅은 inline `[hooks]` 또는 user-level hooks로 안내
+
+---
+
+## 7. 테스트 전략
+
+| 레벨 | 범위 |
+|---|---|
+| 단위 | `isOmhHookCommand`, strip 유틸, Claude/Codex hook merge |
+| 통합 | `computeUninstall` 플랜, 실행 후 디스크 상태 |
+| E2E(tmux) | sync → 사용자 편집 → sync → uninstall → 보존/제거 검증 |
+
+완료: `npm run lint` + `npm test` + T7 통과.
+
+---
+
+## 8. 리스크 / 결정 필요 항목
+
+1. **Codex `.codex/hooks.json` 소유권**
+   - 최대 결정 사항.
+   - 사용자 안전 우선이면 병합형 승격(A).
+   - 구현 단순성과 기존 가정 유지면 전용 계약(B), 대신 경고/문서가 필수.
+2. **사용자 콘텐츠 오삭제**
+   - 모든 제거는 마커/메타/`.omh/hooks` 경로 기반.
+   - 불확실하면 보존.
+3. **한 matcher group에 사용자 hook과 OMH hook이 섞인 경우**
+   - hook command 단위 partition 필요.
+   - entry 단위 삭제만 하면 사용자 hook까지 지울 수 있다.
+4. **Codex TOML 주석 손실**
+   - 기존 코드의 알려진 trade-off.
+   - uninstall에서도 TOML parser round-trip 사용 시 주석 손실 가능. 문서화 또는 regex-free 대안 검토.
+5. **Pi generated file 직접 편집**
+   - `.pi/extensions/omh-harness.ts`는 전용 파일로 명시.
+   - 사용자 커스터마이징은 별도 `.pi/extensions/*.ts` 파일로 안내.
+6. **manifest 없는 레거시 프로젝트**
+   - 마커/경로 기반 best-effort 제거.
+7. **명령 이름**
+   - `uninstall` 유지 권장. `clean`은 범위가 모호하고 `purge`와 혼동 가능.
+
+---
+
+## 9. PR 분할
+
+### PR-1 — 훅 보존 버그픽스
+
+- `isOmhHookCommand`
+- Claude hooks 병합
+- Codex hooks 정책 결정 및 구현
+- 관련 단위 테스트
+
+### PR-2 — uninstall 순수 로직
+
+- strip 유틸
+- `computeUninstall`
+- 플랜 테스트
+
+### PR-3 — CLI + 문서 + E2E
+
+- `omh uninstall` command
+- dry-run/confirm/yes/purge
+- README
+- tmux 통합 QA
+
+단일 PR도 가능하지만, sync 시 사용자 훅 clobber는 uninstall과 독립적인 선재 버그이므로 PR-1을 먼저 내는 것이 안전하다.

--- a/README.md
+++ b/README.md
@@ -273,12 +273,44 @@ omh hook remove auto-pr                   # Remove a hook
 
 # 🔄 Sync & manage
 omh sync                                 # Regenerate all files from harness.yaml
+omh uninstall --dry-run                  # Preview generated-file cleanup
+omh uninstall -y                         # Remove generated files, keep user content
+omh uninstall -y --purge                 # Also remove harness.yaml
 
 # 🩺 Verify & monitor
 omh doctor                               # Health check
 omh test                                  # Dry-run verify all hooks
 omh stats                                 # TUI analytics dashboard
 ```
+
+### 🧹 `omh uninstall` — Safe generated-file cleanup
+
+`omh uninstall` removes oh-my-harness generated artifacts while preserving user
+content in merged files.
+
+```bash
+omh uninstall --dry-run
+omh uninstall -y
+omh uninstall -y --purge
+```
+
+Safety behavior:
+
+- Prints the same uninstall plan for dry-run and real execution.
+- Recommends backing up before execution; use `--skip-backup-warning` only for
+  automation that already handles backups.
+- Keeps `harness.yaml` by default; `--purge` removes it.
+- Preserves user content in `CLAUDE.md`, `AGENTS.md`, `.claude/settings.json`,
+  `.codex/hooks.json`, `.codex/config.toml`, and user Pi extensions.
+- Removes only OMH-owned hook commands that point at this project's
+  `.omh/hooks` directory.
+- Warns when `.codex/config.toml` feature flags (`hooks`/`goals`) are removed,
+  because manually-owned feature settings cannot be distinguished from OMH
+  generated settings.
+- Warns that `.codex/config.toml` comments may be lost when TOML is rewritten.
+- Uses backups for modified files and restores them on stop-on-error failures;
+  `--continue-on-error` records failures and keeps applying independent
+  operations.
 
 ### 🩺 `omh doctor`
 
@@ -440,6 +472,7 @@ oh-my-harness/
 - [x] Unified `.omh/` layout — single source of truth for hooks & state across runtimes
 - [x] Pi ([pi.dev](https://pi.dev)) emitter — bridge extension (`.pi/extensions/omh-harness.ts`) reusing the same `.omh/hooks/*.sh`
 - [x] `ask` mode — request approval before executing risky tools (Claude native prompt / Pi `ctx.ui.select`; Codex falls back to block)
+- [x] `omh uninstall` — remove generated artifacts while preserving user content
 - [ ] Community harness.yaml registry — share and reuse configs
 - [ ] `omh modify "change X"` — NL config editing
 

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -1,0 +1,104 @@
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+import {
+  applyUninstallPlan,
+  computeUninstall,
+  type UninstallPlan,
+  type UninstallResult,
+} from "../../core/uninstall.js";
+
+export interface UninstallOptions {
+  projectDir?: string;
+  dryRun?: boolean;
+  yes?: boolean;
+  purge?: boolean;
+  skipBackupWarning?: boolean;
+  continueOnError?: boolean;
+}
+
+export interface UninstallCommandResult {
+  exitCode: number;
+  plan: UninstallPlan;
+  result?: UninstallResult;
+}
+
+function visibleWarnings(plan: UninstallPlan, options: UninstallOptions): string[] {
+  return plan.destructiveWarnings.filter((warning) =>
+    !(options.skipBackupWarning && warning.includes("백업 후 실행 권장")),
+  );
+}
+
+export function renderUninstallPlan(plan: UninstallPlan, options: UninstallOptions = {}): string {
+  const warnings = visibleWarnings(plan, options);
+  const lines = [
+    "oh-my-harness uninstall plan",
+    `- delete: ${plan.delete.length} files/directories`,
+    `- modify: ${plan.modify.length} files`,
+    `- keep: ${plan.keptHarnessYaml ? "harness.yaml" : "none"}`,
+    `- warnings: ${warnings.length}`,
+  ];
+
+  if (warnings.length > 0) {
+    lines.push("", "Safety:");
+    for (const warning of warnings) lines.push(`- ${warning}`);
+  }
+
+  if (plan.modify.length > 0) {
+    lines.push("", "modify:");
+    for (const item of plan.modify) lines.push(`  ${item.path}`);
+  }
+  if (plan.delete.length > 0) {
+    lines.push("", "delete:");
+    for (const target of plan.delete) lines.push(`  ${target}`);
+  }
+  if (plan.removeDirs.length > 0) {
+    lines.push("", "remove empty dirs:");
+    for (const dir of plan.removeDirs) lines.push(`  ${dir}`);
+  }
+
+  return lines.join("\n");
+}
+
+function renderResult(result: UninstallResult): string {
+  const lines = [
+    "oh-my-harness uninstall result",
+    `modified: ${result.modified.length}`,
+    `deleted: ${result.deleted.length}`,
+    `removedDirs: ${result.removedDirs.length}`,
+    `restored: ${result.restored.length}`,
+    `failed: ${result.failed.length}`,
+  ];
+  for (const failure of result.failed) {
+    lines.push(`  ${failure.op}: ${failure.path} — ${failure.message}`);
+  }
+  return lines.join("\n");
+}
+
+async function confirmUninstall(): Promise<boolean> {
+  const rl = createInterface({ input, output });
+  try {
+    const answer = await rl.question("Proceed with uninstall? Type 'yes' to continue: ");
+    return answer.trim().toLowerCase() === "yes";
+  } finally {
+    rl.close();
+  }
+}
+
+export async function uninstallCommand(options: UninstallOptions = {}): Promise<UninstallCommandResult> {
+  const projectDir = options.projectDir ?? process.cwd();
+  const plan = await computeUninstall({ projectDir, purge: options.purge });
+  console.log(renderUninstallPlan(plan, options));
+
+  if (options.dryRun) {
+    return { exitCode: 0, plan };
+  }
+
+  if (!options.yes && !await confirmUninstall()) {
+    console.log("oh-my-harness: uninstall cancelled");
+    return { exitCode: 1, plan };
+  }
+
+  const result = await applyUninstallPlan(plan, { continueOnError: options.continueOnError });
+  console.log(renderResult(result));
+  return { exitCode: result.failed.length === 0 ? 0 : 1, plan, result };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -82,6 +82,30 @@ export function createCli(): Command {
     });
 
   program
+    .command("uninstall")
+    .description("Safely remove oh-my-harness generated files while preserving user content")
+    .option("-d, --project-dir <dir>", "Project directory")
+    .option("--dry-run", "Print the uninstall plan without writing")
+    .option("-y, --yes", "Skip confirmation prompt")
+    .option("--purge", "Also delete harness.yaml")
+    .option("--skip-backup-warning", "Suppress the backup recommendation")
+    .option("--continue-on-error", "Keep applying independent operations after failures")
+    .action(async (options: {
+      projectDir?: string;
+      dryRun?: boolean;
+      yes?: boolean;
+      purge?: boolean;
+      skipBackupWarning?: boolean;
+      continueOnError?: boolean;
+    }) => {
+      const { uninstallCommand } = await import("./commands/uninstall.js");
+      const result = await uninstallCommand(options);
+      if (result.exitCode !== 0) {
+        process.exitCode = result.exitCode;
+      }
+    });
+
+  program
     .command("stats")
     .description("TUI dashboard for harness analytics")
     .action(async () => {

--- a/src/core/managed-hooks.ts
+++ b/src/core/managed-hooks.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { OMH_HOOKS_DIR } from "../utils/paths.js";
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error;
+}
+
+function isStrictDescendant(parent: string, child: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function stripWrappingQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === "'" && last === "'") || (first === "\"" && last === "\"")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function extractCommandCandidates(command: string): string[] {
+  const candidates: string[] = [];
+  const quoted = /(['"])(.*?)\1/g;
+  for (const match of command.matchAll(quoted)) {
+    if (match[2]) candidates.push(match[2]);
+  }
+  for (const token of command.split(/\s+/)) {
+    const stripped = stripWrappingQuotes(token.trim());
+    if (stripped) candidates.push(stripped);
+  }
+  return Array.from(new Set(candidates));
+}
+
+async function realpathIfPresent(filePath: string): Promise<string | null> {
+  try {
+    return await fs.realpath(filePath);
+  } catch (err) {
+    if (isErrnoException(err) && err.code === "ENOENT") return null;
+    return null;
+  }
+}
+
+/**
+ * Return true only when a hook command points at a script owned by this project
+ * under `.omh/hooks`. The check prefers realpath boundaries so a symlink inside
+ * `.omh/hooks` that points outside the project is not treated as managed.
+ */
+export async function isOmhHookCommand(command: unknown, projectDir: string): Promise<boolean> {
+  if (typeof command !== "string" || command.trim() === "") return false;
+
+  const hooksDir = path.join(projectDir, OMH_HOOKS_DIR);
+  const hooksDirReal = await realpathIfPresent(hooksDir);
+  if (!hooksDirReal) return false;
+
+  const hooksDirResolved = path.resolve(hooksDir);
+  for (const candidate of extractCommandCandidates(command)) {
+    const absolute = path.isAbsolute(candidate) ? candidate : path.resolve(projectDir, candidate);
+    const candidateReal = await realpathIfPresent(absolute);
+    if (candidateReal) {
+      if (isStrictDescendant(hooksDirReal, candidateReal)) return true;
+      continue;
+    }
+
+    // Stale generated hooks may have been removed before settings/config merge.
+    // Fall back to lexical containment only for paths already under this
+    // project's hooks directory; real files and symlinks always use realpath.
+    const resolved = path.resolve(absolute);
+    if (path.isAbsolute(candidate) && isStrictDescendant(hooksDirResolved, resolved)) return true;
+  }
+
+  return false;
+}

--- a/src/core/uninstall.ts
+++ b/src/core/uninstall.ts
@@ -1,0 +1,339 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parse, stringify } from "smol-toml";
+import { extractManagedSections, removeManagedSection } from "../utils/markdown.js";
+import { isOmhHookCommand } from "./managed-hooks.js";
+
+export interface ComputeUninstallOptions {
+  projectDir: string;
+  purge?: boolean;
+}
+
+export interface UninstallPlan {
+  delete: string[];
+  modify: Array<{ path: string; content: string; backupPath?: string }>;
+  removeDirs: string[];
+  keptHarnessYaml: boolean;
+  warnings: string[];
+  destructiveWarnings: string[];
+}
+
+export interface UninstallResult {
+  modified: string[];
+  deleted: string[];
+  removedDirs: string[];
+  restored: string[];
+  failed: Array<{ path: string; op: "modify" | "delete" | "removeDir" | "restore"; message: string }>;
+  warnings: string[];
+}
+
+export interface ApplyUninstallOptions {
+  continueOnError?: boolean;
+}
+
+function isErrnoException(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function nullIfEmptyObject(value: Record<string, unknown>): Record<string, unknown> | null {
+  return Object.keys(value).length === 0 ? null : value;
+}
+
+export function stripManagedMarkdown(content: string): string | null {
+  let stripped = content;
+  for (const { id } of extractManagedSections(content)) {
+    stripped = removeManagedSection(stripped, id);
+  }
+  stripped = stripped.replace(/^\n+/, "").replace(/[ \t]+\n/g, "\n");
+  if (stripped.trim() === "") return null;
+  return stripped.endsWith("\n") ? stripped : `${stripped}\n`;
+}
+
+async function stripHookEntries(existingHooks: unknown, projectDir: string): Promise<Record<string, unknown[]> | undefined> {
+  if (!isPlainObject(existingHooks)) return undefined;
+  const result: Record<string, unknown[]> = {};
+
+  for (const [event, entries] of Object.entries(existingHooks)) {
+    const eventEntries = Array.isArray(entries) ? entries : [entries];
+    for (const entry of eventEntries) {
+      if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
+        if (!result[event]) result[event] = [];
+        result[event].push(entry);
+        continue;
+      }
+
+      const userHooks: unknown[] = [];
+      for (const hook of entry.hooks) {
+        if (
+          isPlainObject(hook) &&
+          typeof hook.command === "string" &&
+          await isOmhHookCommand(hook.command, projectDir)
+        ) {
+          continue;
+        }
+        userHooks.push(hook);
+      }
+      if (userHooks.length > 0) {
+        if (!result[event]) result[event] = [];
+        result[event].push({ ...entry, hooks: userHooks });
+      }
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+export async function stripClaudeSettings(
+  settings: Record<string, unknown>,
+  projectDir: string,
+): Promise<Record<string, unknown> | null> {
+  const result: Record<string, unknown> = { ...settings };
+  const meta = isPlainObject(settings._ohMyHarness) ? settings._ohMyHarness : {};
+  const managedPermissions = isPlainObject(meta.managedPermissions) ? meta.managedPermissions : {};
+  const managedAllow = new Set(asStringArray(managedPermissions.allow));
+  const managedDeny = new Set(asStringArray(managedPermissions.deny));
+
+  if (isPlainObject(settings.permissions)) {
+    const permissions: Record<string, unknown> = { ...settings.permissions };
+    const allow = asStringArray(permissions.allow).filter((item) => !managedAllow.has(item));
+    const deny = asStringArray(permissions.deny).filter((item) => !managedDeny.has(item));
+    if (allow.length > 0) permissions.allow = allow;
+    else delete permissions.allow;
+    if (deny.length > 0) permissions.deny = deny;
+    else delete permissions.deny;
+
+    if (Object.keys(permissions).length > 0) result.permissions = permissions;
+    else delete result.permissions;
+  }
+
+  const hooks = await stripHookEntries(settings.hooks, projectDir);
+  if (hooks) result.hooks = hooks;
+  else delete result.hooks;
+
+  delete result._ohMyHarness;
+  return nullIfEmptyObject(result);
+}
+
+export function stripCodexConfigToml(content: string): { content: string | null; warnings: string[] } {
+  const warnings = [
+    ".codex/config.toml: [features].hooks/goals 제거 예정. 사용자가 직접 설정한 값이면 복원이 필요할 수 있습니다.",
+    ".codex/config.toml: 수정 시 TOML in-file comments가 제거될 수 있습니다.",
+  ];
+  if (!content.trim()) return { content: null, warnings: [] };
+
+  const data = parse(content) as Record<string, unknown>;
+  if (isPlainObject(data.features)) {
+    delete data.features.hooks;
+    delete data.features.goals;
+    delete data.features.codex_hooks;
+    if (Object.keys(data.features).length === 0) delete data.features;
+  }
+
+  if (Object.keys(data).length === 0) return { content: null, warnings };
+  return { content: `${stringify(data)}\n`, warnings };
+}
+
+export async function stripCodexHooksJson(
+  hooksJson: Record<string, unknown>,
+  projectDir: string,
+): Promise<Record<string, unknown> | null> {
+  const hooks = await stripHookEntries(hooksJson.hooks, projectDir);
+  if (!hooks) return null;
+  return { ...hooksJson, hooks };
+}
+
+export function stripGitignoreSection(content: string): string | null {
+  const lines = content.split("\n").map((line) => line.replace(/\r$/, ""));
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === "# oh-my-harness") {
+      i++;
+      while (i < lines.length && lines[i].trim() !== "") i++;
+      continue;
+    }
+    out.push(lines[i]);
+  }
+  const stripped = out.join("\n").replace(/\n{3,}/g, "\n\n");
+  return stripped.trim() === "" ? null : (stripped.endsWith("\n") ? stripped : `${stripped}\n`);
+}
+
+async function readTextIfExists(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (err) {
+    if (isErrnoException(err) && err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+async function planTextMutation(
+  plan: UninstallPlan,
+  filePath: string,
+  nextContent: string | null,
+): Promise<void> {
+  if (!await exists(filePath)) return;
+  if (nextContent === null) plan.delete.push(filePath);
+  else plan.modify.push({ path: filePath, content: nextContent });
+}
+
+export async function computeUninstall(options: ComputeUninstallOptions): Promise<UninstallPlan> {
+  const { projectDir, purge = false } = options;
+  const plan: UninstallPlan = {
+    delete: [],
+    modify: [],
+    removeDirs: [],
+    keptHarnessYaml: !purge,
+    warnings: [],
+    destructiveWarnings: ["백업 후 실행 권장: uninstall은 파일을 수정/삭제하는 파괴적 작업입니다."],
+  };
+
+  for (const target of [
+    path.join(projectDir, ".omh"),
+    path.join(projectDir, ".claude", "oh-my-harness.json"),
+    path.join(projectDir, ".pi", "extensions", "omh-harness.ts"),
+  ]) {
+    if (await exists(target)) plan.delete.push(target);
+  }
+
+  if (purge && await exists(path.join(projectDir, "harness.yaml"))) {
+    plan.delete.push(path.join(projectDir, "harness.yaml"));
+    plan.keptHarnessYaml = false;
+  }
+
+  for (const markdownPath of [path.join(projectDir, "CLAUDE.md"), path.join(projectDir, "AGENTS.md")]) {
+    const content = await readTextIfExists(markdownPath);
+    if (content !== null) await planTextMutation(plan, markdownPath, stripManagedMarkdown(content));
+  }
+
+  const settingsPath = path.join(projectDir, ".claude", "settings.json");
+  const settingsRaw = await readTextIfExists(settingsPath);
+  if (settingsRaw !== null) {
+    const stripped = await stripClaudeSettings(JSON.parse(settingsRaw) as Record<string, unknown>, projectDir);
+    await planTextMutation(plan, settingsPath, stripped ? `${JSON.stringify(stripped, null, 2)}\n` : null);
+  }
+
+  const codexHooksPath = path.join(projectDir, ".codex", "hooks.json");
+  const codexHooksRaw = await readTextIfExists(codexHooksPath);
+  if (codexHooksRaw !== null) {
+    const stripped = await stripCodexHooksJson(JSON.parse(codexHooksRaw) as Record<string, unknown>, projectDir);
+    await planTextMutation(plan, codexHooksPath, stripped ? `${JSON.stringify(stripped, null, 2)}\n` : null);
+  }
+
+  const codexTomlPath = path.join(projectDir, ".codex", "config.toml");
+  const codexTomlRaw = await readTextIfExists(codexTomlPath);
+  if (codexTomlRaw !== null) {
+    const stripped = stripCodexConfigToml(codexTomlRaw);
+    plan.warnings.push(...stripped.warnings);
+    plan.destructiveWarnings.push(...stripped.warnings);
+    await planTextMutation(plan, codexTomlPath, stripped.content);
+  }
+
+  const gitignorePath = path.join(projectDir, ".gitignore");
+  const gitignoreRaw = await readTextIfExists(gitignorePath);
+  if (gitignoreRaw !== null) await planTextMutation(plan, gitignorePath, stripGitignoreSection(gitignoreRaw));
+
+  plan.removeDirs.push(
+    path.join(projectDir, ".pi", "extensions"),
+    path.join(projectDir, ".pi"),
+    path.join(projectDir, ".codex"),
+    path.join(projectDir, ".claude"),
+  );
+
+  return plan;
+}
+
+async function restoreBackups(backups: Map<string, string>, result: UninstallResult): Promise<void> {
+  for (const [target, backup] of backups) {
+    try {
+      await fs.copyFile(backup, target);
+      result.restored.push(target);
+    } catch (err) {
+      result.failed.push({ path: target, op: "restore", message: (err as Error).message });
+    }
+  }
+}
+
+export async function applyUninstallPlan(
+  plan: UninstallPlan,
+  options: ApplyUninstallOptions = {},
+): Promise<UninstallResult> {
+  const result: UninstallResult = {
+    modified: [],
+    deleted: [],
+    removedDirs: [],
+    restored: [],
+    failed: [],
+    warnings: [...plan.warnings],
+  };
+  const backups = new Map<string, string>();
+  const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-uninstall-backup-"));
+
+  const recordFailure = async (
+    pathName: string,
+    op: "modify" | "delete" | "removeDir",
+    err: unknown,
+  ): Promise<boolean> => {
+    result.failed.push({ path: pathName, op, message: (err as Error).message });
+    if (!options.continueOnError) {
+      await restoreBackups(backups, result);
+      return false;
+    }
+    return true;
+  };
+
+  try {
+    for (const item of plan.modify) {
+      try {
+        const backup = path.join(backupDir, `${backups.size}.bak`);
+        await fs.copyFile(item.path, backup);
+        backups.set(item.path, backup);
+        await fs.writeFile(item.path, item.content, "utf8");
+        result.modified.push(item.path);
+      } catch (err) {
+        if (!await recordFailure(item.path, "modify", err)) return result;
+      }
+    }
+
+    for (const target of plan.delete) {
+      try {
+        await fs.rm(target, { recursive: true, force: false });
+        result.deleted.push(target);
+      } catch (err) {
+        if (!await recordFailure(target, "delete", err)) return result;
+      }
+    }
+
+    for (const dir of plan.removeDirs) {
+      try {
+        await fs.rmdir(dir);
+        result.removedDirs.push(dir);
+      } catch (err) {
+        if (isErrnoException(err) && (err.code === "ENOENT" || err.code === "ENOTEMPTY")) continue;
+        if (!await recordFailure(dir, "removeDir", err)) return result;
+      }
+    }
+
+    return result;
+  } finally {
+    await fs.rm(backupDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+

--- a/src/core/uninstall.ts
+++ b/src/core/uninstall.ts
@@ -140,13 +140,19 @@ export function stripCodexConfigToml(content: string): { content: string | null;
   if (!content.trim()) return { content: null, warnings: [] };
 
   const data = parse(content) as Record<string, unknown>;
+  let deletedAny = false;
   if (isPlainObject(data.features)) {
-    delete data.features.hooks;
-    delete data.features.goals;
-    delete data.features.codex_hooks;
+    for (const key of ["hooks", "goals", "codex_hooks"]) {
+      if (Object.prototype.hasOwnProperty.call(data.features, key)) {
+        delete data.features[key];
+        deletedAny = true;
+      }
+    }
+    if (!deletedAny) return { content, warnings: [] };
     if (Object.keys(data.features).length === 0) delete data.features;
   }
 
+  if (!deletedAny) return { content, warnings: [] };
   if (Object.keys(data).length === 0) return { content: null, warnings };
   return { content: `${stringify(data)}\n`, warnings };
 }
@@ -336,4 +342,3 @@ export async function applyUninstallPlan(
     await fs.rm(backupDir, { recursive: true, force: true }).catch(() => undefined);
   }
 }
-

--- a/src/generators/codex-config.ts
+++ b/src/generators/codex-config.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { parse, stringify } from "smol-toml";
 import type { HooksOutput } from "./hooks.js";
+import { isOmhHookCommand } from "../core/managed-hooks.js";
 
 export interface GenerateCodexConfigOptions {
   projectDir: string;
@@ -48,6 +49,12 @@ export interface CodexHooksFile {
   hooks: Record<string, Array<{ matcher: string; hooks: Array<{ type: "command"; command: string }> }>>;
 }
 
+type CodexHookEntry = { matcher?: unknown; hooks?: unknown };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 export function buildCodexHooks(hooksOutput: HooksOutput): {
   codexHooks: CodexHooksFile;
   skipped: string[];
@@ -67,6 +74,95 @@ export function buildCodexHooks(hooksOutput: HooksOutput): {
   }
 
   return { codexHooks, skipped };
+}
+
+function normalizeExistingCodexHooks(raw: string): Record<string, unknown[]> {
+  if (!raw.trim()) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `oh-my-harness: .codex/hooks.json is invalid JSON; ` +
+        `fix it before re-running sync to avoid losing user hooks. (${(err as Error).message})`,
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error("oh-my-harness: incompatible Codex hooks schema in .codex/hooks.json.");
+  }
+  const hooks = parsed.hooks;
+  if (hooks === undefined) return {};
+  if (!isPlainObject(hooks)) {
+    throw new Error("oh-my-harness: incompatible Codex hooks schema in .codex/hooks.json.");
+  }
+
+  const normalized: Record<string, unknown[]> = {};
+  for (const [event, entries] of Object.entries(hooks)) {
+    if (Array.isArray(entries)) {
+      normalized[event] = entries;
+    } else if (isPlainObject(entries)) {
+      normalized[event] = [entries];
+    } else {
+      throw new Error(`oh-my-harness: incompatible Codex hooks schema for event ${event}.`);
+    }
+  }
+  return normalized;
+}
+
+async function stripOmhHooksFromCodexEntries(
+  entries: unknown[],
+  projectDir: string,
+): Promise<unknown[]> {
+  const preserved: unknown[] = [];
+  for (const entry of entries) {
+    if (!isPlainObject(entry)) {
+      throw new Error("oh-my-harness: incompatible Codex hooks entry in .codex/hooks.json.");
+    }
+    const hooks = (entry as CodexHookEntry).hooks;
+    if (!Array.isArray(hooks)) {
+      throw new Error("oh-my-harness: incompatible Codex hooks handler list in .codex/hooks.json.");
+    }
+
+    const userHooks: unknown[] = [];
+    for (const hook of hooks) {
+      if (
+        isPlainObject(hook) &&
+        typeof hook.command === "string" &&
+        await isOmhHookCommand(hook.command, projectDir)
+      ) {
+        continue;
+      }
+      userHooks.push(hook);
+    }
+
+    if (userHooks.length > 0) preserved.push({ ...entry, hooks: userHooks });
+  }
+  return preserved;
+}
+
+export async function mergeCodexHooksFile(
+  existingRaw: string,
+  generated: CodexHooksFile,
+  projectDir: string,
+): Promise<CodexHooksFile> {
+  const existing = normalizeExistingCodexHooks(existingRaw);
+  const merged: CodexHooksFile = { hooks: {} };
+
+  for (const [event, entries] of Object.entries(existing)) {
+    const preserved = await stripOmhHooksFromCodexEntries(entries, projectDir);
+    if (preserved.length > 0) {
+      merged.hooks[event] = preserved as CodexHooksFile["hooks"][string];
+    }
+  }
+
+  for (const [event, entries] of Object.entries(generated.hooks)) {
+    if (!merged.hooks[event]) merged.hooks[event] = [];
+    merged.hooks[event].push(...entries);
+  }
+
+  return merged;
 }
 
 /**
@@ -135,16 +231,24 @@ export async function computeCodexConfig(
   const { codexHooks } = buildCodexHooks(hooksOutput);
 
   let existingToml = "";
+  let existingHooks = "";
   try {
     existingToml = await fs.readFile(tomlPath, "utf8");
   } catch (err) {
     const error = err as NodeJS.ErrnoException;
     if (error.code !== "ENOENT") throw error;
   }
+  try {
+    existingHooks = await fs.readFile(hooksPath, "utf8");
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException;
+    if (error.code !== "ENOENT") throw error;
+  }
   const newToml = buildCodexConfigToml(existingToml);
+  const newHooks = await mergeCodexHooksFile(existingHooks, codexHooks, projectDir);
 
   return [
-    { path: hooksPath, content: JSON.stringify(codexHooks, null, 2) + "\n" },
+    { path: hooksPath, content: JSON.stringify(newHooks, null, 2) + "\n" },
     { path: tomlPath, content: newToml },
   ];
 }

--- a/src/generators/settings.ts
+++ b/src/generators/settings.ts
@@ -26,12 +26,9 @@ async function preserveUserHooks(
 
   const preserved: Record<string, unknown[]> = {};
   for (const [event, entries] of Object.entries(existingHooks)) {
-    if (!Array.isArray(entries)) {
-      preserved[event] = [entries];
-      continue;
-    }
+    const eventEntries = Array.isArray(entries) ? entries : [entries];
 
-    for (const entry of entries) {
+    for (const entry of eventEntries) {
       if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
         if (!preserved[event]) preserved[event] = [];
         preserved[event].push(entry);

--- a/src/generators/settings.ts
+++ b/src/generators/settings.ts
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { MergedConfig } from "../core/merged-config.js";
 import type { HooksOutput } from "./hooks.js";
+import { isOmhHookCommand } from "../core/managed-hooks.js";
 
 export interface GenerateSettingsOptions {
   projectDir: string;
@@ -11,6 +12,76 @@ export interface GenerateSettingsOptions {
 
 function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function preserveUserHooks(
+  existingHooks: unknown,
+  projectDir: string,
+): Promise<Record<string, unknown[]>> {
+  if (!isPlainObject(existingHooks)) return {};
+
+  const preserved: Record<string, unknown[]> = {};
+  for (const [event, entries] of Object.entries(existingHooks)) {
+    if (!Array.isArray(entries)) {
+      preserved[event] = [entries];
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!isPlainObject(entry) || !Array.isArray(entry.hooks)) {
+        if (!preserved[event]) preserved[event] = [];
+        preserved[event].push(entry);
+        continue;
+      }
+
+      const userHooks: unknown[] = [];
+      for (const hook of entry.hooks) {
+        if (
+          isPlainObject(hook) &&
+          typeof hook.command === "string" &&
+          await isOmhHookCommand(hook.command, projectDir)
+        ) {
+          continue;
+        }
+        userHooks.push(hook);
+      }
+
+      if (userHooks.length > 0) {
+        if (!preserved[event]) preserved[event] = [];
+        preserved[event].push({ ...entry, hooks: userHooks });
+      }
+    }
+  }
+
+  return preserved;
+}
+
+async function mergeHooksConfig(
+  existingHooks: unknown,
+  generatedHooks: HooksOutput["hooksConfig"],
+  projectDir: string,
+): Promise<Record<string, unknown[]>> {
+  const preserved = await preserveUserHooks(existingHooks, projectDir);
+  const merged: Record<string, unknown[]> = {};
+  for (const [event, entries] of Object.entries(preserved)) {
+    if (entries.length > 0) merged[event] = [...entries];
+  }
+  for (const [event, entries] of Object.entries(generatedHooks)) {
+    if (!merged[event]) merged[event] = [];
+    const seen = new Set(merged[event].map((entry) => JSON.stringify(entry)));
+    for (const entry of entries) {
+      const key = JSON.stringify(entry);
+      if (!seen.has(key)) {
+        merged[event].push(entry);
+        seen.add(key);
+      }
+    }
+  }
+  return merged;
 }
 
 /**
@@ -76,6 +147,7 @@ export async function computeSettings(
   const mergedAllow = Array.from(new Set([...userAllow, ...newManagedAllow]));
   const mergedDeny = Array.from(new Set([...userDeny, ...newManagedDeny]));
   const previousManagedAt = existingMeta.managedAt;
+  const mergedHooks = await mergeHooksConfig(existing.hooks, hooksOutput.hooksConfig, projectDir);
 
   const result: Record<string, unknown> = {
     ...existing,
@@ -84,7 +156,7 @@ export async function computeSettings(
       allow: mergedAllow,
       deny: mergedDeny,
     },
-    hooks: hooksOutput.hooksConfig,
+    hooks: mergedHooks,
     _ohMyHarness: {
       managedAt: "__PLACEHOLDER__",
       presets: config.presets,

--- a/tests/integration/cli-index.test.ts
+++ b/tests/integration/cli-index.test.ts
@@ -26,8 +26,18 @@ describe("createCli wiring", () => {
     expect(hasOption(find(program, "doctor"), "--strict")).toBe(true);
   });
 
+  it("registers uninstall with safety options", () => {
+    const uninstall = find(program, "uninstall");
+    expect(uninstall).toBeDefined();
+    expect(hasOption(uninstall, "--dry-run")).toBe(true);
+    expect(hasOption(uninstall, "--yes")).toBe(true);
+    expect(hasOption(uninstall, "--purge")).toBe(true);
+    expect(hasOption(uninstall, "--skip-backup-warning")).toBe(true);
+    expect(hasOption(uninstall, "--continue-on-error")).toBe(true);
+  });
+
   it("still registers the existing core commands", () => {
-    for (const name of ["init", "sync", "doctor", "test", "stats"]) {
+    for (const name of ["init", "sync", "doctor", "test", "stats", "uninstall"]) {
       expect(find(program, name)).toBeDefined();
     }
   });

--- a/tests/integration/cli-uninstall.test.ts
+++ b/tests/integration/cli-uninstall.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import yaml from "js-yaml";
+import { syncCommand } from "../../src/cli/commands/sync.js";
+import { uninstallCommand } from "../../src/cli/commands/uninstall.js";
+
+let projectDir: string;
+
+function captureConsole(): { output: () => string; restore: () => void } {
+  const lines: string[] = [];
+  const log = vi.spyOn(console, "log").mockImplementation((...args) => { lines.push(args.join(" ")); });
+  const error = vi.spyOn(console, "error").mockImplementation((...args) => { lines.push(args.join(" ")); });
+  return {
+    output: () => lines.join("\n"),
+    restore: () => {
+      log.mockRestore();
+      error.mockRestore();
+    },
+  };
+}
+
+async function withConsole<T>(fn: () => Promise<T>): Promise<{ result: T; output: string }> {
+  const cap = captureConsole();
+  try {
+    const result = await fn();
+    return { result, output: cap.output() };
+  } finally {
+    cap.restore();
+  }
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function harnessYaml(): string {
+  return yaml.dump(
+    {
+      version: "1.0",
+      project: { name: "uninstall-test", stacks: [{ name: "frontend", framework: "react", language: "typescript" }] },
+      rules: [{ id: "rule", title: "Rule", content: "managed rule", priority: 50 }],
+      permissions: { allow: ["Bash(pnpm test*)"], deny: ["Bash(rm -rf /)"] },
+      hooks: [{ block: "command-guard", params: { patterns: ["DO_NOT_RUN"] } }],
+    },
+    { lineWidth: 120 },
+  );
+}
+
+async function prepareSyncedProject(): Promise<void> {
+  await fs.writeFile(path.join(projectDir, "harness.yaml"), harnessYaml(), "utf8");
+  await syncCommand({ projectDir });
+
+  await fs.appendFile(path.join(projectDir, "CLAUDE.md"), "\nuser claude note\n", "utf8");
+  await fs.appendFile(path.join(projectDir, "AGENTS.md"), "\nuser agents note\n", "utf8");
+
+  const settingsPath = path.join(projectDir, ".claude", "settings.json");
+  const settings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
+  settings.permissions.allow.push("Bash(git push)");
+  settings.hooks.PreToolUse.push({
+    matcher: "Bash",
+    hooks: [{ type: "command", command: "node custom-claude-hook.js" }],
+  });
+  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf8");
+
+  const codexConfigPath = path.join(projectDir, ".codex", "config.toml");
+  await fs.appendFile(
+    codexConfigPath,
+    [
+      "",
+      "[[hooks.PreToolUse]]",
+      'matcher = "^Bash$"',
+      "",
+      "[[hooks.PreToolUse.hooks]]",
+      'type = "command"',
+      'command = "python3 inline-user-hook.py"',
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const codexHooksPath = path.join(projectDir, ".codex", "hooks.json");
+  const codexHooks = JSON.parse(await fs.readFile(codexHooksPath, "utf8"));
+  codexHooks.hooks.PreToolUse.unshift({
+    matcher: "Bash",
+    hooks: [{ type: "command", command: "python3 user-codex-hook.py" }],
+  });
+  await fs.writeFile(codexHooksPath, JSON.stringify(codexHooks, null, 2) + "\n", "utf8");
+
+  await fs.writeFile(path.join(projectDir, ".pi", "extensions", "custom.ts"), "export default 'user';\n", "utf8");
+}
+
+beforeEach(async () => {
+  projectDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-uninstall-cli-"));
+});
+
+afterEach(async () => {
+  await fs.rm(projectDir, { recursive: true, force: true });
+});
+
+describe("uninstallCommand", () => {
+  it("dry-run prints destructive warnings and does not write", async () => {
+    await prepareSyncedProject();
+    const before = await fs.readFile(path.join(projectDir, ".claude", "settings.json"), "utf8");
+
+    const { result, output } = await withConsole(() => uninstallCommand({ projectDir, dryRun: true }));
+
+    expect(result.exitCode).toBe(0);
+    expect(output).toContain("oh-my-harness uninstall plan");
+    expect(output).toContain("백업 후 실행 권장");
+    expect(output).toContain("[features].hooks/goals");
+    expect(output).toContain("comments");
+    await expect(fs.readFile(path.join(projectDir, ".claude", "settings.json"), "utf8")).resolves.toBe(before);
+  });
+
+  it("removes generated artifacts and preserves user content", async () => {
+    await prepareSyncedProject();
+
+    const { result, output } = await withConsole(() => uninstallCommand({ projectDir, yes: true }));
+
+    expect(result.exitCode).toBe(0);
+    expect(output).toContain("modified:");
+    expect(output).toContain("deleted:");
+    await expect(exists(path.join(projectDir, ".omh"))).resolves.toBe(false);
+    await expect(exists(path.join(projectDir, ".pi", "extensions", "omh-harness.ts"))).resolves.toBe(false);
+    await expect(fs.readFile(path.join(projectDir, ".pi", "extensions", "custom.ts"), "utf8")).resolves.toContain("user");
+    await expect(fs.readFile(path.join(projectDir, "harness.yaml"), "utf8")).resolves.toContain("version");
+
+    const claudeMd = await fs.readFile(path.join(projectDir, "CLAUDE.md"), "utf8");
+    expect(claudeMd).toContain("user claude note");
+    expect(claudeMd).not.toContain("oh-my-harness:start");
+
+    const settings = JSON.parse(await fs.readFile(path.join(projectDir, ".claude", "settings.json"), "utf8"));
+    expect(settings.permissions.allow).toEqual(["Bash(git push)"]);
+    expect(JSON.stringify(settings.hooks)).toContain("node custom-claude-hook.js");
+    expect(JSON.stringify(settings.hooks)).not.toContain(".omh/hooks");
+    expect(settings._ohMyHarness).toBeUndefined();
+
+    const codexHooks = JSON.parse(await fs.readFile(path.join(projectDir, ".codex", "hooks.json"), "utf8"));
+    expect(JSON.stringify(codexHooks)).toContain("python3 user-codex-hook.py");
+    expect(JSON.stringify(codexHooks)).not.toContain(".omh/hooks");
+
+    const codexConfig = await fs.readFile(path.join(projectDir, ".codex", "config.toml"), "utf8");
+    expect(codexConfig).toContain("inline-user-hook.py");
+    expect(codexConfig).toContain("[mcp_servers.foo]");
+    expect(codexConfig).not.toContain("hooks = true");
+    expect(codexConfig).not.toContain("goals = true");
+  });
+
+  it("purges harness.yaml when requested", async () => {
+    await prepareSyncedProject();
+
+    const result = await uninstallCommand({ projectDir, yes: true, purge: true, skipBackupWarning: true });
+
+    expect(result.exitCode).toBe(0);
+    await expect(exists(path.join(projectDir, "harness.yaml"))).resolves.toBe(false);
+  });
+});
+

--- a/tests/unit/codex-config-generator.test.ts
+++ b/tests/unit/codex-config-generator.test.ts
@@ -305,4 +305,100 @@ describe("generateCodexConfig", () => {
     const hooksJson = JSON.parse(await fs.readFile(path.join(tmpDir, ".codex/hooks.json"), "utf8"));
     expect(hooksJson).toEqual({ hooks: {} });
   });
+
+  it("preserves user hooks while replacing previously generated OMH hooks", async () => {
+    const codexDir = path.join(tmpDir, ".codex");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
+    await fs.mkdir(codexDir, { recursive: true });
+    await fs.mkdir(hooksDir, { recursive: true });
+    const oldOmhHook = path.join(hooksDir, "old.sh");
+    const newOmhHook = path.join(hooksDir, "new.sh");
+    await fs.writeFile(oldOmhHook, "#!/usr/bin/env bash\n", "utf8");
+    await fs.writeFile(newOmhHook, "#!/usr/bin/env bash\n", "utf8");
+    await fs.writeFile(
+      path.join(codexDir, "hooks.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              { matcher: "Bash", hooks: [{ type: "command", command: "python3 user-hook.py" }] },
+              { matcher: "Bash", hooks: [{ type: "command", command: `bash '${oldOmhHook}'` }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+
+    await generateCodexConfig({
+      projectDir: tmpDir,
+      hooksOutput: {
+        hooksConfig: {
+          PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: `bash '${newOmhHook}'` }] }],
+        },
+        generatedFiles: [newOmhHook],
+      },
+    });
+
+    const hooksJson = JSON.parse(await fs.readFile(path.join(codexDir, "hooks.json"), "utf8"));
+    const commands = hooksJson.hooks.PreToolUse.flatMap((entry: any) => entry.hooks.map((hook: any) => hook.command));
+    expect(commands).toEqual(["python3 user-hook.py", `bash '${newOmhHook}'`]);
+  });
+
+  it("normalizes a single user hook object to an ordered array before merging", async () => {
+    const codexDir = path.join(tmpDir, ".codex");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
+    await fs.mkdir(codexDir, { recursive: true });
+    await fs.mkdir(hooksDir, { recursive: true });
+    const newOmhHook = path.join(hooksDir, "new.sh");
+    await fs.writeFile(newOmhHook, "#!/usr/bin/env bash\n", "utf8");
+    await fs.writeFile(
+      path.join(codexDir, "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: { matcher: "Bash", hooks: [{ type: "command", command: "python3 user-hook.py" }] },
+        },
+      }) + "\n",
+      "utf8",
+    );
+
+    await generateCodexConfig({
+      projectDir: tmpDir,
+      hooksOutput: {
+        hooksConfig: {
+          PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: `bash '${newOmhHook}'` }] }],
+        },
+        generatedFiles: [newOmhHook],
+      },
+    });
+
+    const hooksJson = JSON.parse(await fs.readFile(path.join(codexDir, "hooks.json"), "utf8"));
+    expect(hooksJson.hooks.PreToolUse.map((entry: any) => entry.hooks[0].command)).toEqual([
+      "python3 user-hook.py",
+      `bash '${newOmhHook}'`,
+    ]);
+  });
+
+  it("refuses to overwrite hooks.json when the hook event schema is incompatible", async () => {
+    const codexDir = path.join(tmpDir, ".codex");
+    await fs.mkdir(codexDir, { recursive: true });
+    const hooksPath = path.join(codexDir, "hooks.json");
+    await fs.writeFile(hooksPath, JSON.stringify({ hooks: { PreToolUse: "future-schema" } }) + "\n", "utf8");
+
+    await expect(
+      generateCodexConfig({
+        projectDir: tmpDir,
+        hooksOutput: {
+          hooksConfig: {
+            PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "bash /tmp/new.sh" }] }],
+          },
+          generatedFiles: [],
+        },
+      }),
+    ).rejects.toThrow(/incompatible Codex hooks/);
+
+    await expect(fs.readFile(hooksPath, "utf8")).resolves.toContain("future-schema");
+  });
 });

--- a/tests/unit/managed-hooks.test.ts
+++ b/tests/unit/managed-hooks.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative, sep } from "node:path";
 import { tmpdir } from "node:os";
 import { isOmhHookCommand } from "../../src/core/managed-hooks.js";
 
@@ -35,7 +35,10 @@ describe("isOmhHookCommand", () => {
     try {
       const outsideScript = join(outside, "evil.sh");
       await writeFile(outsideScript, "#!/usr/bin/env bash\n", "utf8");
-      const traversal = join(projectDir, ".omh", "hooks", "..", "..", "..", outsideScript);
+      const hooksDir = join(projectDir, ".omh", "hooks");
+      const outsideRelativeToHooks = relative(hooksDir, outsideScript);
+      expect(outsideRelativeToHooks).toContain("..");
+      const traversal = `${hooksDir}${sep}${outsideRelativeToHooks}`;
 
       await expect(isOmhHookCommand(`bash '${traversal}'`, projectDir)).resolves.toBe(false);
     } finally {

--- a/tests/unit/managed-hooks.test.ts
+++ b/tests/unit/managed-hooks.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { isOmhHookCommand } from "../../src/core/managed-hooks.js";
+
+let projectDir: string;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "omh-managed-hooks-"));
+  await mkdir(join(projectDir, ".omh", "hooks"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe("isOmhHookCommand", () => {
+  it("recognizes generated hook commands under project .omh/hooks", async () => {
+    const script = join(projectDir, ".omh", "hooks", "guard.sh");
+    await writeFile(script, "#!/usr/bin/env bash\n", "utf8");
+
+    await expect(isOmhHookCommand(`bash '${script}'`, projectDir)).resolves.toBe(true);
+    await expect(isOmhHookCommand(`bash \"${script}\"`, projectDir)).resolves.toBe(true);
+    await expect(isOmhHookCommand(script, projectDir)).resolves.toBe(true);
+  });
+
+  it("does not classify user hook commands as managed", async () => {
+    await expect(isOmhHookCommand("node myhook.js", projectDir)).resolves.toBe(false);
+    await expect(isOmhHookCommand("python3 ~/.codex/hooks/foo.py", projectDir)).resolves.toBe(false);
+  });
+
+  it("rejects traversal paths that resolve outside project .omh/hooks", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "outside-omh-hooks-"));
+    try {
+      const outsideScript = join(outside, "evil.sh");
+      await writeFile(outsideScript, "#!/usr/bin/env bash\n", "utf8");
+      const traversal = join(projectDir, ".omh", "hooks", "..", "..", "..", outsideScript);
+
+      await expect(isOmhHookCommand(`bash '${traversal}'`, projectDir)).resolves.toBe(false);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symlinks inside .omh/hooks that point outside the hooks directory", async () => {
+    const outside = await mkdtemp(join(tmpdir(), "outside-hook-target-"));
+    try {
+      const outsideScript = join(outside, "target.sh");
+      await writeFile(outsideScript, "#!/usr/bin/env bash\n", "utf8");
+      const link = join(projectDir, ".omh", "hooks", "linked.sh");
+      await symlink(outsideScript, link);
+
+      await expect(isOmhHookCommand(`bash '${link}'`, projectDir)).resolves.toBe(false);
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it("does not trust a plain string that merely mentions .omh/hooks", async () => {
+    await expect(isOmhHookCommand("echo .omh/hooks/guard.sh", projectDir)).resolves.toBe(false);
+  });
+});

--- a/tests/unit/settings-generator.test.ts
+++ b/tests/unit/settings-generator.test.ts
@@ -131,6 +131,56 @@ describe("generateSettings", () => {
     expect(settings.permissions.deny).toContain("Bash(rm -rf /)");
   });
 
+  it("preserves user hooks while replacing previously generated OMH hooks", async () => {
+    const claudeDir = path.join(tmpDir, ".claude");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.mkdir(hooksDir, { recursive: true });
+    const oldOmhHook = path.join(hooksDir, "old-guard.sh");
+    const newOmhHook = path.join(hooksDir, "new-guard.sh");
+    await fs.writeFile(oldOmhHook, "#!/usr/bin/env bash\n", "utf-8");
+    await fs.writeFile(newOmhHook, "#!/usr/bin/env bash\n", "utf-8");
+
+    await fs.writeFile(
+      path.join(claudeDir, "settings.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: "Bash",
+                hooks: [
+                  { type: "command", command: "node custom-hook.js" },
+                  { type: "command", command: `bash '${oldOmhHook}'` },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    await generateSettings({
+      projectDir: tmpDir,
+      config: makeMergedConfig(),
+      hooksOutput: {
+        hooksConfig: {
+          PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: `bash '${newOmhHook}'` }] }],
+        },
+        generatedFiles: [newOmhHook],
+      } as any,
+    });
+
+    const settings = JSON.parse(await fs.readFile(path.join(claudeDir, "settings.json"), "utf-8"));
+    const commands = settings.hooks.PreToolUse.flatMap((entry: any) => entry.hooks.map((hook: any) => hook.command));
+
+    expect(commands).toContain("node custom-hook.js");
+    expect(commands).toContain(`bash '${newOmhHook}'`);
+    expect(commands).not.toContain(`bash '${oldOmhHook}'`);
+  });
+
   it("removes managed permissions that were removed from harness.yaml", async () => {
     const hooksOutput = makeHooksOutput();
 

--- a/tests/unit/settings-generator.test.ts
+++ b/tests/unit/settings-generator.test.ts
@@ -4,11 +4,7 @@ import path from "node:path";
 import os from "node:os";
 import { generateSettings } from "../../src/generators/settings.js";
 import type { MergedConfig } from "../../src/core/preset-types.js";
-
-interface HooksOutput {
-  hooksConfig: Record<string, Array<{ matcher: string; hooks: string[] }>>;
-  generatedFiles: string[];
-}
+import type { HooksOutput } from "../../src/generators/hooks.js";
 
 const makeMergedConfig = (overrides: Partial<MergedConfig> = {}): MergedConfig => ({
   presets: ["_base", "nextjs"],
@@ -26,11 +22,33 @@ const makeMergedConfig = (overrides: Partial<MergedConfig> = {}): MergedConfig =
 
 const makeHooksOutput = (overrides: Partial<HooksOutput> = {}): HooksOutput => ({
   hooksConfig: {
-    PreToolUse: [{ matcher: "Bash", hooks: ["~/.claude/hooks/command-guard.sh"] }],
+    PreToolUse: [
+      {
+        matcher: "Bash",
+        hooks: [{ type: "command", command: "~/.claude/hooks/command-guard.sh" }],
+      },
+    ],
   },
   generatedFiles: [],
   ...overrides,
 });
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function collectPreToolUseCommands(settings: unknown): string[] {
+  if (!isRecord(settings) || !isRecord(settings.hooks)) return [];
+  const preToolUse = settings.hooks.PreToolUse;
+  if (!Array.isArray(preToolUse)) return [];
+
+  return preToolUse.flatMap((entry) => {
+    if (!isRecord(entry) || !Array.isArray(entry.hooks)) return [];
+    return entry.hooks.flatMap((hook) => (
+      isRecord(hook) && typeof hook.command === "string" ? [hook.command] : []
+    ));
+  });
+}
 
 let tmpDir: string;
 
@@ -170,11 +188,59 @@ describe("generateSettings", () => {
           PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: `bash '${newOmhHook}'` }] }],
         },
         generatedFiles: [newOmhHook],
-      } as any,
+      },
     });
 
     const settings = JSON.parse(await fs.readFile(path.join(claudeDir, "settings.json"), "utf-8"));
-    const commands = settings.hooks.PreToolUse.flatMap((entry: any) => entry.hooks.map((hook: any) => hook.command));
+    const commands = collectPreToolUseCommands(settings);
+
+    expect(commands).toContain("node custom-hook.js");
+    expect(commands).toContain(`bash '${newOmhHook}'`);
+    expect(commands).not.toContain(`bash '${oldOmhHook}'`);
+  });
+
+  it("filters managed commands from single-object hook events before merging", async () => {
+    const claudeDir = path.join(tmpDir, ".claude");
+    const hooksDir = path.join(tmpDir, ".omh", "hooks");
+    await fs.mkdir(claudeDir, { recursive: true });
+    await fs.mkdir(hooksDir, { recursive: true });
+    const oldOmhHook = path.join(hooksDir, "old-guard.sh");
+    const newOmhHook = path.join(hooksDir, "new-guard.sh");
+    await fs.writeFile(oldOmhHook, "#!/usr/bin/env bash\n", "utf-8");
+    await fs.writeFile(newOmhHook, "#!/usr/bin/env bash\n", "utf-8");
+
+    await fs.writeFile(
+      path.join(claudeDir, "settings.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: {
+              matcher: "Bash",
+              hooks: [
+                { type: "command", command: "node custom-hook.js" },
+                { type: "command", command: `bash '${oldOmhHook}'` },
+              ],
+            },
+          },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+
+    await generateSettings({
+      projectDir: tmpDir,
+      config: makeMergedConfig(),
+      hooksOutput: {
+        hooksConfig: {
+          PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: `bash '${newOmhHook}'` }] }],
+        },
+        generatedFiles: [newOmhHook],
+      },
+    });
+
+    const settings = JSON.parse(await fs.readFile(path.join(claudeDir, "settings.json"), "utf-8"));
+    const commands = collectPreToolUseCommands(settings);
 
     expect(commands).toContain("node custom-hook.js");
     expect(commands).toContain(`bash '${newOmhHook}'`);

--- a/tests/unit/uninstall-core.test.ts
+++ b/tests/unit/uninstall-core.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, mkdir, writeFile, readFile, access, chmod } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  applyUninstallPlan,
+  computeUninstall,
+  stripClaudeSettings,
+  stripCodexConfigToml,
+  stripGitignoreSection,
+  stripManagedMarkdown,
+} from "../../src/core/uninstall.js";
+
+let projectDir: string;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "omh-uninstall-core-"));
+});
+
+afterEach(async () => {
+  await chmod(projectDir, 0o755).catch(() => undefined);
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe("uninstall strip helpers", () => {
+  it("removes all managed markdown sections and preserves user text", () => {
+    const result = stripManagedMarkdown(
+      [
+        "user intro",
+        "<!-- oh-my-harness:start:a -->",
+        "managed",
+        "<!-- oh-my-harness:end:a -->",
+        "user outro",
+      ].join("\n"),
+    );
+
+    expect(result).toContain("user intro");
+    expect(result).toContain("user outro");
+    expect(result).not.toContain("oh-my-harness:start");
+  });
+
+  it("strips Claude managed permissions/hooks/meta but keeps user content", async () => {
+    const hooksDir = join(projectDir, ".omh", "hooks");
+    await mkdir(hooksDir, { recursive: true });
+    const omhHook = join(hooksDir, "guard.sh");
+    await writeFile(omhHook, "#!/usr/bin/env bash\n", "utf8");
+
+    const result = await stripClaudeSettings(
+      {
+        userCustomKey: "keep",
+        permissions: {
+          allow: ["Bash(git push)", "Bash(pnpm test*)"],
+          deny: ["Bash(rm -rf /)"],
+        },
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: "Bash",
+              hooks: [
+                { type: "command", command: "node custom-hook.js" },
+                { type: "command", command: `bash '${omhHook}'` },
+              ],
+            },
+          ],
+        },
+        _ohMyHarness: {
+          managedPermissions: {
+            allow: ["Bash(pnpm test*)"],
+            deny: ["Bash(rm -rf /)"],
+          },
+        },
+      },
+      projectDir,
+    );
+
+    expect(result).toMatchObject({
+      userCustomKey: "keep",
+      permissions: { allow: ["Bash(git push)"] },
+      hooks: {
+        PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "node custom-hook.js" }] }],
+      },
+    });
+    expect(result).not.toHaveProperty("_ohMyHarness");
+  });
+
+  it("removes OMH feature flags from Codex config while warning about user-owned ambiguity", () => {
+    const stripped = stripCodexConfigToml(
+      [
+        "[features]",
+        "hooks = true",
+        "goals = true",
+        "some_other_flag = true",
+        "",
+        "[mcp_servers.foo]",
+        'command = "bar"',
+      ].join("\n"),
+    );
+
+    expect(stripped.content).toContain("some_other_flag = true");
+    expect(stripped.content).toContain("[mcp_servers.foo]");
+    expect(stripped.content).not.toContain("hooks = true");
+    expect(stripped.content).not.toContain("goals = true");
+    expect(stripped.warnings.join("\n")).toContain("[features].hooks/goals");
+    expect(stripped.warnings.join("\n")).toContain("comments");
+  });
+
+  it("removes the oh-my-harness gitignore section only", () => {
+    const result = stripGitignoreSection(["node_modules/", "", "# oh-my-harness", ".omh/state/", "", "dist/"].join("\n"));
+    expect(result).toBe(["node_modules/", "", "dist/", ""].join("\n"));
+  });
+});
+
+describe("computeUninstall and applyUninstallPlan", () => {
+  it("plans and applies safe removal while preserving user-owned files", async () => {
+    await mkdir(join(projectDir, ".omh", "hooks"), { recursive: true });
+    await mkdir(join(projectDir, ".claude"), { recursive: true });
+    await mkdir(join(projectDir, ".codex"), { recursive: true });
+    await mkdir(join(projectDir, ".pi", "extensions"), { recursive: true });
+    await writeFile(join(projectDir, ".omh", "hooks", "guard.sh"), "#!/usr/bin/env bash\n", "utf8");
+    await writeFile(join(projectDir, ".claude", "oh-my-harness.json"), "{}\n", "utf8");
+    await writeFile(join(projectDir, ".pi", "extensions", "omh-harness.ts"), "generated\n", "utf8");
+    await writeFile(join(projectDir, ".pi", "extensions", "custom.ts"), "user\n", "utf8");
+    await writeFile(join(projectDir, "harness.yaml"), "presets: []\n", "utf8");
+    await writeFile(
+      join(projectDir, "CLAUDE.md"),
+      "hello\n<!-- oh-my-harness:start:x -->\nmanaged\n<!-- oh-my-harness:end:x -->\n",
+      "utf8",
+    );
+
+    const plan = await computeUninstall({ projectDir });
+    expect(plan.delete).toContain(join(projectDir, ".omh"));
+    expect(plan.delete).toContain(join(projectDir, ".claude", "oh-my-harness.json"));
+    expect(plan.delete).toContain(join(projectDir, ".pi", "extensions", "omh-harness.ts"));
+    expect(plan.keptHarnessYaml).toBe(true);
+    expect(plan.destructiveWarnings.join("\n")).toContain("백업 후 실행 권장");
+
+    const result = await applyUninstallPlan(plan);
+    expect(result.failed).toEqual([]);
+    await expect(readFile(join(projectDir, "CLAUDE.md"), "utf8")).resolves.toBe("hello\n");
+    await expect(readFile(join(projectDir, ".pi", "extensions", "custom.ts"), "utf8")).resolves.toBe("user\n");
+    await expect(exists(join(projectDir, ".omh"))).resolves.toBe(false);
+    await expect(exists(join(projectDir, "harness.yaml"))).resolves.toBe(true);
+  });
+
+  it("purges harness.yaml only when requested", async () => {
+    await writeFile(join(projectDir, "harness.yaml"), "presets: []\n", "utf8");
+    const plan = await computeUninstall({ projectDir, purge: true });
+    expect(plan.delete).toContain(join(projectDir, "harness.yaml"));
+  });
+
+  it("restores modified files on stop-on-error failure", async () => {
+    const keep = join(projectDir, "CLAUDE.md");
+    await writeFile(keep, "original\n", "utf8");
+    const plan = {
+      delete: [join(projectDir, "does-not-exist", "file")],
+      modify: [{ path: keep, content: "changed\n" }],
+      removeDirs: [],
+      keptHarnessYaml: false,
+      warnings: [],
+      destructiveWarnings: [],
+    };
+
+    const result = await applyUninstallPlan(plan);
+
+    expect(result.failed[0]?.op).toBe("delete");
+    await expect(readFile(keep, "utf8")).resolves.toBe("original\n");
+    expect(result.restored).toContain(keep);
+  });
+});
+

--- a/tests/unit/uninstall-core.test.ts
+++ b/tests/unit/uninstall-core.test.ts
@@ -113,6 +113,23 @@ describe("uninstall strip helpers", () => {
     expect(stripped.warnings.join("\n")).toContain("comments");
   });
 
+  it("leaves Codex config untouched when no managed feature flags exist", () => {
+    const original = [
+      "# keep my comments",
+      "[features]",
+      "some_other_flag = true",
+      "",
+      "[mcp_servers.foo]",
+      'command = "bar"',
+      "",
+    ].join("\n");
+
+    const stripped = stripCodexConfigToml(original);
+
+    expect(stripped.content).toBe(original);
+    expect(stripped.warnings).toEqual([]);
+  });
+
   it("removes the oh-my-harness gitignore section only", () => {
     const result = stripGitignoreSection(["node_modules/", "", "# oh-my-harness", ".omh/state/", "", "dist/"].join("\n"));
     expect(result).toBe(["node_modules/", "", "dist/", ""].join("\n"));
@@ -176,4 +193,3 @@ describe("computeUninstall and applyUninstallPlan", () => {
     expect(result.restored).toContain(keep);
   });
 });
-


### PR DESCRIPTION
The uninstall plan now records the repo-local verification that Codex hooks.json has the same clobber risk as Claude settings.json, while Pi remains a generated-file ownership concern. It separates Codex hooks.json from config.toml inline hooks and updates the implementation/test breakdown around an explicit Codex ownership decision.\n\nConstraint: .omc is ignored locally, so the requested plan file was force-added intentionally.\nRejected: Treat Codex as issue-free | project hooks.json is a documented Codex hook source and current generator rewrites it wholesale.\nConfidence: high\nScope-risk: narrow\nTested: npm run lint; npm test\nNot-tested: PR push/creation not attempted from this local session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * omh uninstall 명령 추가 — --dry-run, -y, --purge, --skip-backup-warning, --continue-on-error 및 계획 미리보기·확인·적용 흐름 제공.

* **Behaviour**
  * 생성된 관리 훅은 갱신하고 사용자 훅·설정은 보존하는 안전한 병합·보호 로직 적용.
  * 안전한 삭제 순서(백업→수정→삭제→정리) 및 오류 복구 정책 지원.

* **Documentation**
  * 명령 사용법, 안전 규칙·경고 문구, 옵션 설명 및 로드맵 업데이트 추가.

* **Tests**
  * 단위·통합·E2E 테스트 추가로 uninstall 및 훅 보존/제거 동작 검증.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->