### PR TITLE
chore(release): bump version to 0.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump package metadata from 0.15.0 to 0.16.0 after the uninstall safety feature merge.
- Update package-lock root/package versions only.

## Verification
- npm run lint
- npm test
- npm run build

## Release note
- Tag v0.16.0 after this PR is merged to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 패키지 버전이 0.16.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->