### PR TITLE
feat(config): add `omh config` to view/reconfigure/reset AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ oh-my-harness/
 - [x] Pi ([pi.dev](https://pi.dev)) emitter — bridge extension (`.pi/extensions/omh-harness.ts`) reusing the same `.omh/hooks/*.sh`
 - [x] `ask` mode — request approval before executing risky tools (Claude native prompt / Pi `ctx.ui.select`; Codex falls back to block)
 - [x] `omh uninstall` — remove generated artifacts while preserving user content
+- [x] `omh config` — view, reconfigure, or reset the saved AI provider (rotate expired keys, switch provider/model)
 - [ ] Community harness.yaml registry — share and reuse configs
 - [ ] `omh modify "change X"` — NL config editing
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -60,6 +60,13 @@ async function defaultSetupRunner(): Promise<ProviderConfig | undefined> {
  * key or switch providers.
  */
 export async function configCommand(options: ConfigOptions = {}): Promise<ConfigResult> {
+  // --show and --reset express contradictory intent; fail loudly rather than
+  // silently letting one win.
+  if (options.show && options.reset) {
+    console.error("`--show` and `--reset` cannot be used together.");
+    return { exitCode: 1 };
+  }
+
   const existing = await loadProviderConfig();
 
   // --show: read-only summary.

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,0 +1,108 @@
+import chalk from "chalk";
+import {
+  loadProviderConfig,
+  deleteProviderConfig,
+  maskApiKey,
+  type ProviderConfig,
+} from "../../nl/config-store.js";
+
+export interface ConfigOptions {
+  /** Print the current provider config (masked) without changing anything. */
+  show?: boolean;
+  /** Delete the saved provider config. */
+  reset?: boolean;
+  /** Skip confirmation prompts. */
+  yes?: boolean;
+  /**
+   * Interactive provider setup. Injectable for tests; defaults to the clack TUI.
+   * Returns the saved config, or undefined if the user cancelled.
+   */
+  setupRunner?: () => Promise<ProviderConfig | undefined>;
+  /** Confirmation prompt. Injectable for tests; defaults to the clack TUI. */
+  confirm?: (message: string) => Promise<boolean>;
+}
+
+export interface ConfigResult {
+  exitCode: number;
+}
+
+const NO_CONFIG_MESSAGE =
+  "No AI provider configured yet. Run `omh config` (or `omh init`) to set one up.";
+
+function printSummary(config: ProviderConfig): void {
+  console.log(chalk.bold("Current AI provider configuration:"));
+  console.log(`  provider: ${chalk.cyan(config.provider)}`);
+  console.log(`  method:   ${chalk.cyan(config.method)}`);
+  if (config.method === "api") {
+    console.log(`  model:    ${chalk.cyan(config.model ?? "(default)")}`);
+    console.log(`  api key:  ${chalk.dim(maskApiKey(config.apiKey))}`);
+  } else {
+    console.log(`  command:  ${chalk.cyan(config.cliCommand ?? config.provider)}`);
+  }
+}
+
+async function defaultConfirm(message: string): Promise<boolean> {
+  const p = await import("@clack/prompts");
+  const answer = await p.confirm({ message });
+  if (p.isCancel(answer)) return false;
+  return answer === true;
+}
+
+async function defaultSetupRunner(): Promise<ProviderConfig | undefined> {
+  const { runProviderSetup } = await import("../tui/provider-setup.js");
+  return runProviderSetup();
+}
+
+/**
+ * `omh config`: view, reconfigure, or reset the saved AI provider used for
+ * natural-language mode (~/.omh/config.json). Without flags it shows the current
+ * config and launches the provider setup flow so a user can rotate an expired
+ * key or switch providers.
+ */
+export async function configCommand(options: ConfigOptions = {}): Promise<ConfigResult> {
+  const existing = await loadProviderConfig();
+
+  // --show: read-only summary.
+  if (options.show) {
+    if (!existing) {
+      console.log(NO_CONFIG_MESSAGE);
+      return { exitCode: 0 };
+    }
+    printSummary(existing);
+    return { exitCode: 0 };
+  }
+
+  // --reset: delete the saved config.
+  if (options.reset) {
+    if (!existing) {
+      console.log(NO_CONFIG_MESSAGE);
+      return { exitCode: 0 };
+    }
+    const confirm = options.confirm ?? defaultConfirm;
+    const ok = options.yes ? true : await confirm("Delete the saved AI provider configuration?");
+    if (!ok) {
+      console.log("Aborted. Configuration left unchanged.");
+      return { exitCode: 0 };
+    }
+    await deleteProviderConfig();
+    console.log(chalk.green("Removed ~/.omh/config.json"));
+    return { exitCode: 0 };
+  }
+
+  // Default: show current config (if any), then reconfigure.
+  if (existing) {
+    printSummary(existing);
+    console.log("");
+  } else {
+    console.log("No AI provider configured yet. Let's set one up.\n");
+  }
+
+  const setupRunner = options.setupRunner ?? defaultSetupRunner;
+  const updated = await setupRunner();
+  if (!updated) {
+    // Setup was cancelled; nothing changed.
+    return { exitCode: 0 };
+  }
+
+  return { exitCode: 0 };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -106,6 +106,20 @@ export function createCli(): Command {
     });
 
   program
+    .command("config")
+    .description("View, reconfigure, or reset the saved AI provider")
+    .option("--show", "Show the current provider config (API key masked)")
+    .option("--reset", "Delete the saved provider config")
+    .option("-y, --yes", "Skip confirmation prompts")
+    .action(async (options: { show?: boolean; reset?: boolean; yes?: boolean }) => {
+      const { configCommand } = await import("./commands/config.js");
+      const result = await configCommand(options);
+      if (result.exitCode !== 0) {
+        process.exitCode = result.exitCode;
+      }
+    });
+
+  program
     .command("stats")
     .description("TUI dashboard for harness analytics")
     .action(async () => {

--- a/src/nl/config-store.ts
+++ b/src/nl/config-store.ts
@@ -45,3 +45,18 @@ export async function saveProviderConfig(config: ProviderConfig): Promise<void> 
   await fs.writeFile(configPath, payload, { encoding: "utf-8", mode: 0o600 });
   await fs.chmod(configPath, 0o600);
 }
+
+export async function deleteProviderConfig(): Promise<void> {
+  await fs.rm(getConfigPath(), { force: true });
+}
+
+/**
+ * Masks an API key for display, keeping a short prefix and suffix so the user
+ * can recognize which key is stored without revealing it. Keys short enough
+ * that a prefix/suffix would overlap are masked entirely.
+ */
+export function maskApiKey(apiKey: string | undefined): string {
+  const key = apiKey?.trim() ?? "";
+  if (key.length <= 8) return "****";
+  return `${key.slice(0, 3)}…${key.slice(-4)}`;
+}

--- a/tests/integration/cli-index.test.ts
+++ b/tests/integration/cli-index.test.ts
@@ -36,8 +36,16 @@ describe("createCli wiring", () => {
     expect(hasOption(uninstall, "--continue-on-error")).toBe(true);
   });
 
+  it("registers the config command with --show and --reset", () => {
+    const config = find(program, "config");
+    expect(config).toBeDefined();
+    expect(hasOption(config, "--show")).toBe(true);
+    expect(hasOption(config, "--reset")).toBe(true);
+    expect(hasOption(config, "--yes")).toBe(true);
+  });
+
   it("still registers the existing core commands", () => {
-    for (const name of ["init", "sync", "doctor", "test", "stats", "uninstall"]) {
+    for (const name of ["init", "sync", "doctor", "test", "stats", "uninstall", "config"]) {
       expect(find(program, name)).toBeDefined();
     }
   });

--- a/tests/unit/cli-config.test.ts
+++ b/tests/unit/cli-config.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { configCommand } from "../../src/cli/commands/config.js";
+import { saveProviderConfig, hasProviderConfig } from "../../src/nl/config-store.js";
+import type { ProviderConfig } from "../../src/nl/config-store.js";
+
+let tmpHome: string;
+let originalHome: string;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+function loggedOutput(): string {
+  return consoleLogSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+beforeEach(async () => {
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "omh-config-cmd-"));
+  originalHome = process.env.HOME ?? "";
+  process.env.HOME = tmpHome;
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  process.env.HOME = originalHome;
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+describe("configCommand --show", () => {
+  it("prints provider, method and model with the API key masked", async () => {
+    await saveProviderConfig({
+      provider: "openai",
+      method: "api",
+      apiKey: "sk-1234567890abcdef",
+      model: "gpt-5.4",
+    });
+
+    const result = await configCommand({ show: true });
+
+    expect(result.exitCode).toBe(0);
+    const out = loggedOutput();
+    expect(out).toContain("openai");
+    expect(out).toContain("gpt-5.4");
+    expect(out).toContain("sk-…cdef");
+    // The raw key must never be printed.
+    expect(out).not.toContain("sk-1234567890abcdef");
+  });
+
+  it("reports when no provider is configured", async () => {
+    const result = await configCommand({ show: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(loggedOutput().toLowerCase()).toContain("no ai provider");
+  });
+});
+
+describe("configCommand --reset", () => {
+  it("deletes the saved config when confirmed", async () => {
+    await saveProviderConfig({ provider: "openai", method: "api", apiKey: "sk-secret" });
+
+    const result = await configCommand({ reset: true, yes: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(await hasProviderConfig()).toBe(false);
+  });
+
+  it("keeps the config when the user declines", async () => {
+    await saveProviderConfig({ provider: "openai", method: "api", apiKey: "sk-secret" });
+
+    const result = await configCommand({
+      reset: true,
+      confirm: async () => false,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(await hasProviderConfig()).toBe(true);
+  });
+
+  it("reports when there is nothing to reset", async () => {
+    const result = await configCommand({ reset: true, yes: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(loggedOutput().toLowerCase()).toContain("no ai provider");
+  });
+});
+
+describe("configCommand (reconfigure)", () => {
+  it("runs the provider setup and persists the new config", async () => {
+    await saveProviderConfig({ provider: "claude", method: "cli", cliCommand: "claude" });
+
+    const newConfig: ProviderConfig = {
+      provider: "gemini",
+      method: "api",
+      apiKey: "key-abcd1234efgh",
+      model: "gemini-2.5-pro",
+    };
+    const setupRunner = vi.fn(async () => {
+      await saveProviderConfig(newConfig);
+      return newConfig;
+    });
+
+    const result = await configCommand({ setupRunner });
+
+    expect(result.exitCode).toBe(0);
+    expect(setupRunner).toHaveBeenCalledOnce();
+    const { loadProviderConfig } = await import("../../src/nl/config-store.js");
+    expect(await loadProviderConfig()).toEqual(newConfig);
+  });
+
+  it("exits cleanly when setup is cancelled", async () => {
+    await saveProviderConfig({ provider: "claude", method: "cli", cliCommand: "claude" });
+
+    const setupRunner = vi.fn(async () => undefined);
+    const result = await configCommand({ setupRunner });
+
+    expect(result.exitCode).toBe(0);
+    expect(setupRunner).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/unit/cli-config.test.ts
+++ b/tests/unit/cli-config.test.ts
@@ -120,3 +120,21 @@ describe("configCommand (reconfigure)", () => {
     expect(setupRunner).toHaveBeenCalledOnce();
   });
 });
+
+describe("configCommand mutually exclusive flags", () => {
+  it("errors when --show and --reset are used together, without touching the config", async () => {
+    await saveProviderConfig({ provider: "openai", method: "api", apiKey: "sk-secret" });
+
+    const result = await configCommand({ show: true, reset: true, yes: true });
+
+    // Conflicting intent must fail loudly rather than silently picking one.
+    expect(result.exitCode).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errOut = consoleErrorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(errOut).toContain("--show");
+    expect(errOut).toContain("--reset");
+    // Neither branch ran: config is untouched and nothing was printed to stdout.
+    expect(await hasProviderConfig()).toBe(true);
+    expect(loggedOutput()).toBe("");
+  });
+});

--- a/tests/unit/nl-config-store.test.ts
+++ b/tests/unit/nl-config-store.test.ts
@@ -6,7 +6,9 @@ import {
   loadProviderConfig,
   saveProviderConfig,
   hasProviderConfig,
+  deleteProviderConfig,
   getConfigDir,
+  maskApiKey,
   type ProviderConfig,
 } from "../../src/nl/config-store.js";
 
@@ -109,5 +111,39 @@ describe("config-store", () => {
     const configPath = path.join(tmpHome, ".omh", "config.json");
     const stat = await fs.stat(configPath);
     expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("deleteProviderConfig removes ~/.omh/config.json", async () => {
+    await saveProviderConfig({ provider: "openai", method: "api", apiKey: "sk-secret" });
+    expect(await hasProviderConfig()).toBe(true);
+
+    await deleteProviderConfig();
+
+    expect(await hasProviderConfig()).toBe(false);
+  });
+
+  it("deleteProviderConfig is a no-op when no config exists", async () => {
+    await expect(deleteProviderConfig()).resolves.toBeUndefined();
+    expect(await hasProviderConfig()).toBe(false);
+  });
+});
+
+describe("maskApiKey", () => {
+  it("masks the middle of a long key, keeping a prefix and suffix", () => {
+    expect(maskApiKey("sk-1234567890abcdef")).toBe("sk-…cdef");
+  });
+
+  it("fully masks short keys to avoid leaking them", () => {
+    expect(maskApiKey("short")).toBe("****");
+    expect(maskApiKey("12345678")).toBe("****");
+  });
+
+  it("trims surrounding whitespace before masking", () => {
+    expect(maskApiKey("  sk-1234567890abcdef  ")).toBe("sk-…cdef");
+  });
+
+  it("returns a placeholder for empty input", () => {
+    expect(maskApiKey("")).toBe("****");
+    expect(maskApiKey(undefined)).toBe("****");
   });
 });


### PR DESCRIPTION
## Why

Once an AI provider was configured, there was **no way to change it**. The provider-setup flow only ran during `omh init` when `hasProviderConfig()` returned false (`init-flow.ts:166`), so a user whose API key expired — or who wanted to switch provider/model — had to hand-edit or delete `~/.omh/config.json`. There was no CLI surface for it.

## What

Adds `omh config`, reusing the existing `runProviderSetup` TUI and config store:

| Command | Behavior |
|---------|----------|
| `omh config` | Show current config (masked), then re-run provider setup |
| `omh config --show` | Print provider/method/model with the API key masked |
| `omh config --reset` | Delete `~/.omh/config.json` (confirm, or `-y` to skip) |

New helpers in `config-store.ts`:
- `deleteProviderConfig()` — remove the saved config
- `maskApiKey()` — `sk-1234567890abcdef` → `sk-…cdef`; keys ≤ 8 chars fully masked

The command logic is decoupled from the TUI via injectable `setupRunner`/`confirm` for testability.

## Testing

- TDD: tests written first, confirmed failing for the right reason, then implemented.
- New tests: `tests/unit/cli-config.test.ts` (show/reset/reconfigure), `maskApiKey` + `deleteProviderConfig` in `tests/unit/nl-config-store.test.ts`, `config` registration in `tests/integration/cli-index.test.ts`.
- Full suite: **1001 passed**. Lint (`tsc --noEmit`): clean.
- Manual smoke test of built CLI: masked `--show`, `--reset -y`, and empty-state messages verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * `omh config` 명령 추가: 저장된 AI provider 설정을 조회하고 재구성하거나 리셋할 수 있습니다.
  * `--show` 옵션: 현재 설정을 안전하게 조회합니다.
  * `--reset` 옵션: 저장된 설정을 삭제합니다.
  * `-y/--yes` 옵션: 확인 프롬프트를 건너뜁니다.

* **문서**
  * README 로드맵 섹션에 config 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->