### PR TITLE
feat(doctor): surface AI provider config status with `omh config` hint

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { parse } from "smol-toml";
 import { OMH_HOOKS_DIR } from "../../utils/paths.js";
 import { computeDrift, HarnessNotFoundError } from "../../core/drift.js";
+import { loadProviderConfig } from "../../nl/config-store.js";
 
 export interface DoctorOptions {
   projectDir?: string;
@@ -28,6 +29,13 @@ export interface DoctorResult {
    * warning unless `strict` is set.
    */
   inSync?: boolean;
+  /**
+   * Whether an AI provider is configured for natural-language mode
+   * (~/.omh/config.json). Informational only — it never affects health, since
+   * the provider is global and optional. Surfaced so users can discover
+   * `omh config` to rotate an expired key or switch provider/model.
+   */
+  providerConfigured: boolean;
   messages: string[];
 }
 
@@ -185,6 +193,11 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
     // No harness.yaml → leave inSync undefined (drift not applicable).
   }
 
+  // 9. AI provider config (~/.omh/config.json). Global and optional, so this is
+  // purely informational (INFO) and never affects health — it just surfaces
+  // `omh config` so users can rotate an expired key or switch provider/model.
+  const providerConfigured = await checkProviderConfig(messages);
+
   const checksHealthy = Object.values(checks).every(Boolean);
   const healthy = checksHealthy && (!options.strict || inSync !== false);
   const exitCode = healthy ? 0 : 1;
@@ -201,5 +214,34 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Doctor
     }
   }
 
-  return { healthy, exitCode, checks, inSync, messages };
+  return { healthy, exitCode, checks, inSync, providerConfigured, messages };
+}
+
+/**
+ * Inspects the global AI provider config and appends an INFO hint to `messages`.
+ * Returns whether a provider is configured. Never reads or echoes the API key.
+ */
+async function checkProviderConfig(messages: string[]): Promise<boolean> {
+  const config = await loadProviderConfig();
+
+  if (!config) {
+    messages.push(
+      "INFO: No AI provider configured for natural-language mode — run `omh config` to set one up.",
+    );
+    return false;
+  }
+
+  if (config.method === "api") {
+    const model = config.model ? `, ${config.model}` : "";
+    messages.push(
+      `INFO: AI provider: ${config.provider} (api${model}). ` +
+        "If your API key expired, run `omh config` to update it or switch provider.",
+    );
+  } else {
+    messages.push(
+      `INFO: AI provider: ${config.provider} (cli). Run \`omh config\` to switch provider or model.`,
+    );
+  }
+
+  return true;
 }

--- a/tests/integration/cli-doctor.test.ts
+++ b/tests/integration/cli-doctor.test.ts
@@ -288,3 +288,70 @@ describe("doctorCommand", () => {
     expect(after.checks.hooksExecutable).toBe(false);
   });
 });
+
+// The AI provider config lives globally at ~/.omh/config.json, so these tests
+// isolate HOME to a temp dir for deterministic results.
+describe("doctorCommand provider check", () => {
+  let tmpHome: string;
+  let originalHome: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omh-doctor-prov-"));
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "omh-doctor-home-"));
+    originalHome = process.env.HOME ?? "";
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    process.env.HOME = originalHome;
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  async function writeProviderConfig(config: unknown): Promise<void> {
+    await fs.mkdir(path.join(tmpHome, ".omh"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpHome, ".omh", "config.json"),
+      JSON.stringify(config, null, 2) + "\n",
+      "utf-8",
+    );
+  }
+
+  it("hints to run `omh config` when an API provider is configured", async () => {
+    await setupInitializedProject(tmpDir);
+    await writeProviderConfig({ provider: "openai", method: "api", apiKey: "sk-secret", model: "gpt-5.4" });
+
+    const result = await doctorCommand({ projectDir: tmpDir });
+
+    expect(result.providerConfigured).toBe(true);
+    const hint = result.messages.find((m) => m.includes("omh config"));
+    expect(hint).toBeDefined();
+    expect(hint).toContain("openai");
+    // Hint should mention key rotation so an expired key is recoverable.
+    expect(hint!.toLowerCase()).toContain("key");
+    // The provider check is informational and never leaks the API key.
+    expect(result.messages.join("\n")).not.toContain("sk-secret");
+    // Informational only — a configured provider does not affect health.
+    expect(result.healthy).toBe(true);
+  });
+
+  it("notes when no AI provider is configured and points at `omh config`", async () => {
+    await setupInitializedProject(tmpDir);
+
+    const result = await doctorCommand({ projectDir: tmpDir });
+
+    expect(result.providerConfigured).toBe(false);
+    expect(result.messages.some((m) => m.includes("omh config"))).toBe(true);
+    // Missing global provider config must not fail project health.
+    expect(result.healthy).toBe(true);
+  });
+
+  it("never fails health for a CLI provider", async () => {
+    await setupInitializedProject(tmpDir);
+    await writeProviderConfig({ provider: "claude", method: "cli", cliCommand: "claude" });
+
+    const result = await doctorCommand({ projectDir: tmpDir });
+
+    expect(result.providerConfigured).toBe(true);
+    expect(result.healthy).toBe(true);
+  });
+});


### PR DESCRIPTION
> Stacked on #89 (`feat/config-command`). Review/merge that first; this PR's base is `feat/config-command` so the diff shows only the doctor change.

## Why

#89 added `omh config`, but it isn't discoverable. A user whose API key expired has no signal pointing them to the fix. `omh doctor` is the natural place to surface it.

## What

Adds an informational provider check to `doctor` (step 9):

- **API provider configured** → `INFO: AI provider: openai (api, gpt-5.4). If your API key expired, run \`omh config\` to update it or switch provider.`
- **CLI provider configured** → `INFO: AI provider: claude (cli). Run \`omh config\` to switch provider or model.`
- **Nothing configured** → `INFO: No AI provider configured for natural-language mode — run \`omh config\` to set one up.`

Design notes:
- **Non-fatal.** The provider config is global (`~/.omh/config.json`) and optional, so it never flips `healthy` or the exit code — even under `--strict`. New `DoctorResult.providerConfigured` field exposes the state.
- **Never echoes the API key** — only provider/method/model are printed.

## Testing

- TDD: tests written first, confirmed failing for the right reason, then implemented.
- New `doctorCommand provider check` suite (HOME isolated to a temp dir for determinism): API-hint + key-rotation wording, no-config hint, key never leaked, and "never fails health" for both api/cli.
- Full suite: **1004 passed**. Lint (`tsc --noEmit`): clean.
- Manual smoke test of built CLI: verified INFO hints for configured/unconfigured cases, key masked out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)