### PR TITLE
Release v0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## v0.17.0 — AI provider config management

Bumps `0.16.0 → 0.17.0`. Merging this `release/v0.17.0` branch triggers `auto-release.yml`, which tags `v0.17.0`, creates the GitHub release, and publishes to npm.

### What's included
- **#89 — `omh config`**: view, reconfigure, or reset the saved AI provider. Previously there was no way to rotate an expired key or switch provider/model once configured.
  - `omh config` — show current config (masked), then re-run provider setup
  - `omh config --show` — print provider/method/model with the API key masked
  - `omh config --reset` — delete `~/.omh/config.json` (confirm, or `-y`)
  - `--show` + `--reset` together now fail with a clear error instead of silently picking one (CodeRabbit review fix)
- **#90 — doctor provider hint**: `omh doctor` surfaces the global AI provider status as an INFO line pointing at `omh config`. Informational only — never affects health, never echoes the API key.

### Verification
- `npm run lint` (tsc --noEmit): clean
- `npm test`: **1005 passed**
- `npm run build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)