### PR TITLE
Release v0.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oh-my-harness",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oh-my-harness",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-harness",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Tame your AI coding agents with natural language",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump package metadata from `0.17.0` to `0.18.0` after merging the Codex OAuth provider work in #92.

Changes:
- `package.json`: `0.18.0`
- `package-lock.json`: `0.18.0`

Why minor:
- Adds Codex OAuth provider support and experimental direct Codex OAuth API mode.
- Updates GPT-side defaults to `gpt-5.5`.

Validation:
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run build`

Constraint: release branch created from `origin/main` after #92 merged as `cfbe91c`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 버전이 0.18.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->